### PR TITLE
Add advanced option strike selection modes

### DIFF
--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -36,8 +36,9 @@ class Leg(BaseModel):
 
     Batch mode legs (parent ``strategy_kind="batch"``):
       * ``segment="options"`` requires ``option_type`` and ``strike_mode``.
-      * ``strike_mode="atm"`` requires ``atm_offset``.
+      * ``strike_mode="atm"`` / ``"spot_based"`` / ``"future_based"`` requires ``atm_offset``.
       * ``strike_mode="strike"`` requires ``strike_value``.
+      * ``strike_mode="premium_*"`` requires ``premium_value``.
 
     Signal mode legs (parent ``strategy_kind="signal"``):
       * Each leg carries its own ``symbol`` + ``exchange``.
@@ -72,13 +73,17 @@ class Leg(BaseModel):
     position: Literal["B", "S"] = "B"
 
     option_type: Optional[Literal["CE", "PE"]] = None
-    strike_mode: Optional[Literal["atm", "strike"]] = None
+    strike_mode: Optional[Literal[
+        "atm", "spot_based", "future_based", "strike",
+        "premium_near", "premium_greater", "premium_lesser",
+    ]] = None
     atm_offset: Optional[str] = Field(
         None,
         pattern=r"^(ATM|ATM[+-]\d+|ITM\d+|OTM\d+)$",
         description="ATM, ATM+1, ATM-1, ITM2, OTM3, etc.",
     )
     strike_value: Optional[float] = Field(None, gt=0)
+    premium_value: Optional[float] = Field(None, gt=0)
 
     # --- Signal-mode fields (None for batch-mode legs) ---
     symbol: Optional[str] = Field(None, min_length=1, max_length=50)
@@ -101,10 +106,16 @@ class Leg(BaseModel):
                 raise ValueError("option_type required when segment='options'")
             if self.strike_mode is None:
                 raise ValueError("strike_mode required when segment='options'")
-            if self.strike_mode == "atm" and not self.atm_offset:
-                raise ValueError("atm_offset required when strike_mode='atm'")
+            if self.strike_mode in ("atm", "spot_based", "future_based") and not self.atm_offset:
+                raise ValueError(
+                    "atm_offset required when strike_mode is spot/future based"
+                )
             if self.strike_mode == "strike" and self.strike_value is None:
                 raise ValueError("strike_value required when strike_mode='strike'")
+            if self.strike_mode in (
+                "premium_near", "premium_greater", "premium_lesser",
+            ) and self.premium_value is None:
+                raise ValueError("premium_value required when strike_mode is premium based")
         else:
             # Non-options legs must not carry option-only fields.
             if self.option_type is not None:

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -128,12 +128,12 @@ def _resolve_leg(
         }
 
     # Options
-    strike_mode = leg.get("strike_mode") or "atm"
+    strike_mode = leg.get("strike_mode") or "spot_based"
     option_type = leg.get("option_type")
     if not option_type:
         raise EngineError(f"Leg {leg.get('id')}: option_type required for options segment")
 
-    if strike_mode == "atm":
+    if strike_mode in ("atm", "spot_based"):
         atm_offset = leg.get("atm_offset") or "ATM"
         if not auth_token or not broker:
             # Without broker auth we can't fetch the underlying's LTP, which
@@ -157,6 +157,26 @@ def _resolve_leg(
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'ATM resolution failed')}")
         return data
 
+    if strike_mode == "future_based":
+        atm_offset = leg.get("atm_offset") or "ATM"
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: future-based resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_future_based(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            atm_offset=atm_offset,
+            option_type=option_type,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'future-based resolution failed')}")
+        return data
+
     if strike_mode == "strike":
         strike_value = leg.get("strike_value")
         if strike_value is None:
@@ -170,6 +190,31 @@ def _resolve_leg(
         )
         if not ok:
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'direct strike not found')}")
+        return data
+
+    if strike_mode in ("premium_near", "premium_greater", "premium_lesser"):
+        premium_value = leg.get("premium_value")
+        if premium_value is None:
+            raise EngineError(
+                f"Leg {leg.get('id')}: premium_value required when strike_mode={strike_mode}"
+            )
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: premium-based resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_premium_based(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            option_type=option_type,
+            premium_value=float(premium_value),
+            mode=strike_mode,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'premium-based resolution failed')}")
         return data
 
     raise EngineError(f"Leg {leg.get('id')}: unknown strike_mode '{strike_mode}'")

--- a/backend/strategy/symbol_resolver.py
+++ b/backend/strategy/symbol_resolver.py
@@ -28,11 +28,14 @@ from typing import Any, Optional
 
 from backend.services.market_data_service import get_expiry_dates
 from backend.services.option_symbol_service import (
+    _fetch_available_strikes,
     _format_strike,
+    _find_near_month_futures,
     _lookup_option_in_db,
     _option_exchange_for,
     get_option_symbol,
 )
+from backend.services.quotes_service import get_multi_quotes_with_auth, get_quotes_with_auth
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +169,61 @@ def resolve_atm(
     )
 
 
+def resolve_future_based(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    atm_offset: str,
+    option_type: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Resolve ATM-relative options using the nearest FUT LTP as reference."""
+    base = underlying.strip().upper()
+    fut_exchange = option_exchange_for(underlying_exchange)
+    fut = _find_near_month_futures(base, fut_exchange)
+    if not fut:
+        return False, {
+            "status": "error",
+            "message": f"No FUT contract found for {base} on {fut_exchange}",
+        }, 404
+
+    ok, quote_data, status_code = get_quotes_with_auth(
+        symbol=fut["symbol"],
+        exchange=fut["exchange"],
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, {
+            "status": "error",
+            "message": (
+                f"Failed to fetch FUT LTP for {fut['symbol']}: "
+                f"{quote_data.get('message', 'unknown error')}"
+            ),
+        }, status_code
+
+    fut_ltp = quote_data.get("data", {}).get("ltp")
+    if fut_ltp is None:
+        return False, {"status": "error", "message": f"LTP not available for {fut['symbol']}"}, 500
+
+    expiry_compact = expiry_date.replace("-", "").upper()
+    return get_option_symbol(
+        underlying=underlying,
+        exchange=underlying_exchange,
+        expiry_date=expiry_compact,
+        offset=atm_offset,
+        option_type=option_type,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+        underlying_ltp=float(fut_ltp),
+    )
+
+
 def resolve_direct_strike(
     *,
     underlying: str,
@@ -211,6 +269,120 @@ def resolve_direct_strike(
         "strike": details["strike"],
         "expiry": details["expiry"],
         "underlying_ltp": None,  # not fetched in direct-strike mode
+    }, 200
+
+
+def _quote_ltp(row: dict[str, Any]) -> Optional[float]:
+    data = row.get("data") if isinstance(row.get("data"), dict) else row
+    value = data.get("ltp") if isinstance(data, dict) else None
+    if value is None:
+        value = row.get("ltp")
+    try:
+        ltp = float(value)
+    except (TypeError, ValueError):
+        return None
+    return ltp if ltp > 0 else None
+
+
+def _quote_symbol(row: dict[str, Any]) -> Optional[str]:
+    symbol = row.get("symbol")
+    if symbol:
+        return str(symbol)
+    data = row.get("data")
+    if isinstance(data, dict) and data.get("symbol"):
+        return str(data["symbol"])
+    return None
+
+
+def resolve_premium_based(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    option_type: str,
+    premium_value: float,
+    mode: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Pick the option whose live premium matches near/greater/lesser mode."""
+    base = underlying.strip().upper()
+    opt_exchange = option_exchange_for(underlying_exchange)
+    expiry_compact = expiry_date.replace("-", "").upper()
+    option_type_u = option_type.upper()
+    if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", expiry_compact):
+        return False, {"status": "error", "message": f"Invalid expiry: {expiry_date}"}, 400
+    if option_type_u not in ("CE", "PE"):
+        return False, {"status": "error", "message": "option_type must be CE or PE"}, 400
+
+    strikes = _fetch_available_strikes(base, expiry_compact, option_type_u, opt_exchange)
+    if not strikes:
+        return False, {
+            "status": "error",
+            "message": f"No strikes found for {base} {expiry_compact} on {opt_exchange}.",
+        }, 404
+
+    details_by_symbol: dict[str, dict[str, Any]] = {}
+    symbols_list = []
+    for strike in strikes:
+        symbol = f"{base}{expiry_compact}{_format_strike(strike)}{option_type_u}"
+        details = _lookup_option_in_db(symbol, opt_exchange)
+        if not details:
+            continue
+        details_by_symbol[details["symbol"]] = details
+        symbols_list.append({"symbol": details["symbol"], "exchange": details["exchange"]})
+
+    if not symbols_list:
+        return False, {
+            "status": "error",
+            "message": f"No tradable option symbols found for {base} {expiry_compact} {option_type_u}.",
+        }, 404
+
+    ok, quote_data, status_code = get_multi_quotes_with_auth(
+        symbols_list=symbols_list,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, quote_data, status_code
+
+    candidates = []
+    for row in quote_data.get("results", []):
+        symbol = _quote_symbol(row)
+        details = details_by_symbol.get(symbol)
+        ltp = _quote_ltp(row)
+        if not details or ltp is None:
+            continue
+        candidates.append((details, ltp))
+
+    if mode == "premium_greater":
+        candidates = [(d, l) for d, l in candidates if l >= premium_value]
+        key = lambda item: (item[1] - premium_value, item[0]["strike"])
+    elif mode == "premium_lesser":
+        candidates = [(d, l) for d, l in candidates if l <= premium_value]
+        key = lambda item: (premium_value - item[1], -float(item[0]["strike"]))
+    else:
+        key = lambda item: (abs(item[1] - premium_value), item[0]["strike"])
+
+    if not candidates:
+        return False, {
+            "status": "error",
+            "message": f"No option premium matched {mode.replace('_', ' ')} {premium_value}.",
+        }, 404
+
+    details, ltp = min(candidates, key=key)
+    return True, {
+        "status": "success",
+        "symbol": details["symbol"],
+        "exchange": details["exchange"],
+        "lotsize": details["lotsize"],
+        "tick_size": details["tick_size"],
+        "strike": details["strike"],
+        "expiry": details["expiry"],
+        "underlying_ltp": None,
+        "option_ltp": ltp,
     }, 200
 
 

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -1776,14 +1776,25 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                 </thead>
                 <tbody>
                   {strategy.legs.map((leg) => {
+                    const strikeMode = leg.strike_mode === "atm"
+                      ? "spot_based"
+                      : leg.strike_mode;
                     const strikeText =
                       leg.segment !== "options"
                         ? "—"
-                        : leg.strike_mode === "strike"
+                        : strikeMode === "strike"
                           ? leg.strike_value != null
                             ? `${leg.strike_value}`
                             : "—"
-                          : `ATM (${leg.atm_offset ?? "ATM"})`;
+                          : strikeMode === "future_based"
+                            ? `Future Based (${leg.atm_offset ?? "ATM"})`
+                            : strikeMode === "premium_near"
+                              ? `Premium near ${leg.premium_value ?? "—"}`
+                              : strikeMode === "premium_greater"
+                                ? `Premium greater ${leg.premium_value ?? "—"}`
+                                : strikeMode === "premium_lesser"
+                                  ? `Premium lesser ${leg.premium_value ?? "—"}`
+                                  : `Spot Based (${leg.atm_offset ?? "ATM"})`;
                     return (
                       <tr key={leg.id} className="border-t">
                         <td className="px-2 py-1.5 font-mono">{leg.id}</td>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -57,6 +57,7 @@ import {
   type StrategyKind,
   type StrategyType,
   type StrategyUpdate,
+  type StrikeMode,
   type UniverseTab,
 } from "@/types/strategy_module";
 import { cn } from "@/lib/utils";
@@ -77,7 +78,7 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     lots: 1,
     position: "S",
     option_type: "CE",
-    strike_mode: "atm",
+    strike_mode: "spot_based",
     atm_offset: "ATM",
     strike_value: null,
     target_pts: null,
@@ -90,8 +91,8 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
 /** Signal-mode leg defaults: cash for stocks (NSE), futures for MCX,
  *  options for index tabs (weekly_monthly / monthly_only — no spot
  *  trading on indices). The user can switch segment per-leg afterwards.
- *  Options legs ride the same option_type / strike_mode / atm_offset /
- *  strike_value pipeline as batch-mode; the engine resolves the actual
+ *  Options legs ride the same option_type / strike selection pipeline as
+ *  batch-mode; the engine resolves the actual
  *  contract at signal time from (leg.symbol, expiry rank, option fields). */
 function freshSignalLeg(id: number, tab: UniverseTab): Leg {
   const allowedSegs = TAB_SEGMENTS[tab];
@@ -112,7 +113,7 @@ function freshSignalLeg(id: number, tab: UniverseTab): Leg {
     lots: 1,
     position: "B",
     option_type: segment === "options" ? "CE" : null,
-    strike_mode: segment === "options" ? "atm" : null,
+    strike_mode: segment === "options" ? "spot_based" : null,
     atm_offset: segment === "options" ? "ATM" : null,
     strike_value: null,
     symbol: "",
@@ -154,6 +155,47 @@ function expiriesFor(tab: UniverseTab, segment: Segment): ExpiryRank[] {
   return TAB_EXPIRIES[tab];
 }
 
+const STRIKE_MODES: Array<{ value: StrikeMode; label: string }> = [
+  { value: "spot_based", label: "Spot Based" },
+  { value: "future_based", label: "Future Based" },
+  { value: "strike", label: "Strike Price" },
+  { value: "premium_near", label: "Premium near" },
+  { value: "premium_greater", label: "Premium greater" },
+  { value: "premium_lesser", label: "Premium lesser" },
+];
+
+const SPOT_OFFSET_MODES = new Set<StrikeMode>(["atm", "spot_based", "future_based"]);
+const PREMIUM_MODES = new Set<StrikeMode>([
+  "premium_near",
+  "premium_greater",
+  "premium_lesser",
+]);
+
+function normalizeStrikeMode(mode: StrikeMode | null | undefined): StrikeMode {
+  return mode === "atm" ? "spot_based" : mode ?? "spot_based";
+}
+
+function strikeModePatch(
+  leg: Leg,
+  mode: StrikeMode | null,
+): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "premium_value"> {
+  if (!mode) {
+    return {
+      strike_mode: null,
+      atm_offset: null,
+      strike_value: null,
+      premium_value: null,
+    };
+  }
+  const normalized = normalizeStrikeMode(mode);
+  return {
+    strike_mode: normalized,
+    atm_offset: SPOT_OFFSET_MODES.has(normalized) ? leg.atm_offset ?? "ATM" : null,
+    strike_value: normalized === "strike" ? leg.strike_value ?? null : null,
+    premium_value: PREMIUM_MODES.has(normalized) ? leg.premium_value ?? null : null,
+  };
+}
+
 function LegCard({
   leg,
   tab,
@@ -190,28 +232,13 @@ function LegCard({
               value={leg.segment}
               onChange={(e) => {
                 const seg = e.target.value as Segment;
-                // Resolve the NEW strike_mode first; the atm_offset /
-                // strike_value defaults must be evaluated against that
-                // (not against `leg.strike_mode`, which may be null after
-                // an earlier round-trip through a non-options segment).
-                // Without this, toggling off→on options leaves
-                // atm_offset=null while strike_mode='atm' and the schema
-                // rejects with "atm_offset required when strike_mode='atm'".
                 const nextStrikeMode =
-                  seg === "options" ? leg.strike_mode ?? "atm" : null;
+                  seg === "options" ? normalizeStrikeMode(leg.strike_mode) : null;
                 onChange({
                   ...leg,
                   segment: seg,
                   option_type: seg === "options" ? leg.option_type ?? "CE" : null,
-                  strike_mode: nextStrikeMode,
-                  atm_offset:
-                    nextStrikeMode === "atm"
-                      ? leg.atm_offset ?? "ATM"
-                      : null,
-                  strike_value:
-                    nextStrikeMode === "strike"
-                      ? leg.strike_value ?? null
-                      : null,
+                  ...strikeModePatch(leg, nextStrikeMode),
                 });
               }}
               className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
@@ -298,33 +325,25 @@ function LegCard({
 
             <div className="space-y-1.5">
               <Label className="text-xs uppercase">Strike mode</Label>
-              <div className="flex h-9 overflow-hidden rounded-md border border-input">
-                {(["atm", "strike"] as const).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => {
-                      onChange({
-                        ...leg,
-                        strike_mode: m,
-                        atm_offset: m === "atm" ? leg.atm_offset ?? "ATM" : null,
-                        strike_value: m === "strike" ? leg.strike_value ?? null : null,
-                      });
-                    }}
-                    className={cn(
-                      "flex-1 text-sm font-medium transition-colors",
-                      leg.strike_mode === m
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-background hover:bg-muted",
-                    )}
-                  >
-                    {m === "atm" ? "ATM-relative" : "Direct strike"}
-                  </button>
+              <select
+                value={normalizeStrikeMode(leg.strike_mode)}
+                onChange={(e) =>
+                  onChange({
+                    ...leg,
+                    ...strikeModePatch(leg, e.target.value as StrikeMode),
+                  })
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+              >
+                {STRIKE_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>
+                    {m.label}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
 
-            {leg.strike_mode === "atm" ? (
+            {SPOT_OFFSET_MODES.has(normalizeStrikeMode(leg.strike_mode)) ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike offset</Label>
                 <select
@@ -339,7 +358,7 @@ function LegCard({
                   ))}
                 </select>
               </div>
-            ) : (
+            ) : normalizeStrikeMode(leg.strike_mode) === "strike" ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike value</Label>
                 <div className="flex gap-2">
@@ -363,6 +382,24 @@ function LegCard({
                 <p className="text-xs text-muted-foreground">
                   Filtered by underlying + resolved expiry rank ({leg.expiry}).
                 </p>
+              </div>
+            ) : (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Premium value</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.premium_value ?? ""}
+                  placeholder="e.g. 100"
+                  onChange={(e) =>
+                    update(
+                      "premium_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
               </div>
             )}
           </div>
@@ -542,26 +579,15 @@ function SignalLegCard({
               value={leg.segment}
               onChange={(e) => {
                 const seg = e.target.value as Segment;
-                // Resolve the new strike_mode first and use it as the
-                // source of truth for the atm_offset / strike_value
-                // defaults — same race fix as the batch LegCard.
                 const nextStrikeMode =
-                  seg === "options" ? leg.strike_mode ?? "atm" : null;
+                  seg === "options" ? normalizeStrikeMode(leg.strike_mode) : null;
                 onChange({
                   ...leg,
                   segment: seg,
                   expiry:
                     seg === "cash" ? null : expiryChoices[0] ?? "current",
                   option_type: seg === "options" ? leg.option_type ?? "CE" : null,
-                  strike_mode: nextStrikeMode,
-                  atm_offset:
-                    nextStrikeMode === "atm"
-                      ? leg.atm_offset ?? "ATM"
-                      : null,
-                  strike_value:
-                    nextStrikeMode === "strike"
-                      ? leg.strike_value ?? null
-                      : null,
+                  ...strikeModePatch(leg, nextStrikeMode),
                 });
               }}
               className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
@@ -646,34 +672,25 @@ function SignalLegCard({
 
             <div className="space-y-1.5">
               <Label className="text-xs uppercase">Strike mode</Label>
-              <div className="flex h-9 overflow-hidden rounded-md border border-input">
-                {(["atm", "strike"] as const).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => {
-                      onChange({
-                        ...leg,
-                        strike_mode: m,
-                        atm_offset: m === "atm" ? leg.atm_offset ?? "ATM" : null,
-                        strike_value:
-                          m === "strike" ? leg.strike_value ?? null : null,
-                      });
-                    }}
-                    className={cn(
-                      "flex-1 text-sm font-medium transition-colors",
-                      leg.strike_mode === m
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-background hover:bg-muted",
-                    )}
-                  >
-                    {m === "atm" ? "ATM-relative" : "Direct strike"}
-                  </button>
+              <select
+                value={normalizeStrikeMode(leg.strike_mode)}
+                onChange={(e) =>
+                  onChange({
+                    ...leg,
+                    ...strikeModePatch(leg, e.target.value as StrikeMode),
+                  })
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+              >
+                {STRIKE_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>
+                    {m.label}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
 
-            {leg.strike_mode === "atm" ? (
+            {SPOT_OFFSET_MODES.has(normalizeStrikeMode(leg.strike_mode)) ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike offset</Label>
                 <select
@@ -688,7 +705,7 @@ function SignalLegCard({
                   ))}
                 </select>
               </div>
-            ) : (
+            ) : normalizeStrikeMode(leg.strike_mode) === "strike" ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike value</Label>
                 <Input
@@ -706,6 +723,28 @@ function SignalLegCard({
                 />
                 <p className="text-xs text-muted-foreground">
                   Engine looks up this strike on {leg.symbol || "<symbol>"}{" "}
+                  {leg.expiry} {leg.option_type} at signal time.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Premium value</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.premium_value ?? ""}
+                  placeholder="e.g. 100"
+                  onChange={(e) =>
+                    update(
+                      "premium_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Engine picks the matching premium on {leg.symbol || "<symbol>"}{" "}
                   {leg.expiry} {leg.option_type} at signal time.
                 </p>
               </div>

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -40,7 +40,14 @@ export type ExpiryRank =
   | "monthly"
   | "current"
   | "next";
-export type StrikeMode = "atm" | "strike";
+export type StrikeMode =
+  | "atm"
+  | "spot_based"
+  | "future_based"
+  | "strike"
+  | "premium_near"
+  | "premium_greater"
+  | "premium_lesser";
 export type Weekday = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
 
 /**
@@ -95,6 +102,7 @@ export interface Leg {
   strike_mode?: StrikeMode | null;
   atm_offset?: string | null;
   strike_value?: number | null;
+  premium_value?: number | null;
 
   // --- Signal-mode fields (null/undefined for batch-mode legs) ---
   symbol?: string | null;


### PR DESCRIPTION
## Summary
- Add additional option strike selection modes to the strategy builder.
- Wire backend resolution for the advanced strike modes.
- Keep UI and detail display aligned with the new strike selections.

## Scope
- Advanced strike mode foundation only.
- New entry logic modes are intentionally handled in a separate PR.
