### PR TITLE
Add entry logic strike selection modes

### DIFF
--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -39,6 +39,7 @@ class Leg(BaseModel):
       * ``strike_mode="atm"`` / ``"spot_based"`` / ``"future_based"`` requires ``atm_offset``.
       * ``strike_mode="atm_pct"`` requires ``atm_pct_value``.
       * ``strike_mode="straddle_width"`` requires ``straddle_width_value``.
+      * ``strike_mode="underlying_pct"`` requires ``underlying_pct_value``.
       * ``strike_mode="strike"`` requires ``strike_value``.
       * ``strike_mode="premium_*"`` requires ``premium_value``.
 
@@ -77,7 +78,7 @@ class Leg(BaseModel):
     option_type: Optional[Literal["CE", "PE"]] = None
     strike_mode: Optional[Literal[
         "atm", "spot_based", "future_based", "strike",
-        "atm_pct", "straddle_width",
+        "atm_pct", "straddle_width", "underlying_pct",
         "premium_near", "premium_greater", "premium_lesser",
     ]] = None
     atm_offset: Optional[str] = Field(
@@ -88,6 +89,7 @@ class Leg(BaseModel):
     strike_value: Optional[float] = Field(None, gt=0)
     atm_pct_value: Optional[float] = Field(None, description="ATM +/- percentage for strike selection")
     straddle_width_value: Optional[float] = Field(None, description="Signed straddle width multiplier")
+    underlying_pct_value: Optional[float] = Field(None, gt=0, description="Option premium target as percent of underlying")
     premium_value: Optional[float] = Field(None, gt=0)
 
     # --- Signal-mode fields (None for batch-mode legs) ---
@@ -119,6 +121,8 @@ class Leg(BaseModel):
                 raise ValueError("atm_pct_value required when strike_mode='atm_pct'")
             if self.strike_mode == "straddle_width" and self.straddle_width_value is None:
                 raise ValueError("straddle_width_value required when strike_mode='straddle_width'")
+            if self.strike_mode == "underlying_pct" and self.underlying_pct_value is None:
+                raise ValueError("underlying_pct_value required when strike_mode='underlying_pct'")
             if self.strike_mode == "strike" and self.strike_value is None:
                 raise ValueError("strike_value required when strike_mode='strike'")
             if self.strike_mode in (

--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -36,8 +36,9 @@ class Leg(BaseModel):
 
     Batch mode legs (parent ``strategy_kind="batch"``):
       * ``segment="options"`` requires ``option_type`` and ``strike_mode``.
-      * ``strike_mode="atm"`` requires ``atm_offset``.
+      * ``strike_mode="atm"`` / ``"spot_based"`` / ``"future_based"`` requires ``atm_offset``.
       * ``strike_mode="strike"`` requires ``strike_value``.
+      * ``strike_mode="premium_*"`` requires ``premium_value``.
 
     Signal mode legs (parent ``strategy_kind="signal"``):
       * Each leg carries its own ``symbol`` + ``exchange``.
@@ -72,13 +73,17 @@ class Leg(BaseModel):
     position: Literal["B", "S"] = "B"
 
     option_type: Optional[Literal["CE", "PE"]] = None
-    strike_mode: Optional[Literal["atm", "strike"]] = None
+    strike_mode: Optional[Literal[
+        "atm", "spot_based", "future_based", "strike",
+        "premium_near", "premium_greater", "premium_lesser",
+    ]] = None
     atm_offset: Optional[str] = Field(
         None,
         pattern=r"^(ATM|ATM[+-]\d+|ITM\d+|OTM\d+)$",
         description="ATM, ATM+1, ATM-1, ITM2, OTM3, etc.",
     )
     strike_value: Optional[float] = Field(None, gt=0)
+    premium_value: Optional[float] = Field(None, gt=0)
 
     # --- Signal-mode fields (None for batch-mode legs) ---
     symbol: Optional[str] = Field(None, min_length=1, max_length=50)
@@ -101,10 +106,16 @@ class Leg(BaseModel):
                 raise ValueError("option_type required when segment='options'")
             if self.strike_mode is None:
                 raise ValueError("strike_mode required when segment='options'")
-            if self.strike_mode == "atm" and not self.atm_offset:
-                raise ValueError("atm_offset required when strike_mode='atm'")
+            if self.strike_mode in ("atm", "spot_based", "future_based") and not self.atm_offset:
+                raise ValueError(
+                    "atm_offset required when strike_mode is spot/future based"
+                )
             if self.strike_mode == "strike" and self.strike_value is None:
                 raise ValueError("strike_value required when strike_mode='strike'")
+            if self.strike_mode in (
+                "premium_near", "premium_greater", "premium_lesser",
+            ) and self.premium_value is None:
+                raise ValueError("premium_value required when strike_mode is premium based")
         else:
             # Non-options legs must not carry option-only fields.
             if self.option_type is not None:

--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -38,6 +38,7 @@ class Leg(BaseModel):
       * ``segment="options"`` requires ``option_type`` and ``strike_mode``.
       * ``strike_mode="atm"`` / ``"spot_based"`` / ``"future_based"`` requires ``atm_offset``.
       * ``strike_mode="atm_pct"`` requires ``atm_pct_value``.
+      * ``strike_mode="straddle_width"`` requires ``straddle_width_value``.
       * ``strike_mode="strike"`` requires ``strike_value``.
       * ``strike_mode="premium_*"`` requires ``premium_value``.
 
@@ -76,7 +77,7 @@ class Leg(BaseModel):
     option_type: Optional[Literal["CE", "PE"]] = None
     strike_mode: Optional[Literal[
         "atm", "spot_based", "future_based", "strike",
-        "atm_pct",
+        "atm_pct", "straddle_width",
         "premium_near", "premium_greater", "premium_lesser",
     ]] = None
     atm_offset: Optional[str] = Field(
@@ -86,6 +87,7 @@ class Leg(BaseModel):
     )
     strike_value: Optional[float] = Field(None, gt=0)
     atm_pct_value: Optional[float] = Field(None, description="ATM +/- percentage for strike selection")
+    straddle_width_value: Optional[float] = Field(None, description="Signed straddle width multiplier")
     premium_value: Optional[float] = Field(None, gt=0)
 
     # --- Signal-mode fields (None for batch-mode legs) ---
@@ -115,6 +117,8 @@ class Leg(BaseModel):
                 )
             if self.strike_mode == "atm_pct" and self.atm_pct_value is None:
                 raise ValueError("atm_pct_value required when strike_mode='atm_pct'")
+            if self.strike_mode == "straddle_width" and self.straddle_width_value is None:
+                raise ValueError("straddle_width_value required when strike_mode='straddle_width'")
             if self.strike_mode == "strike" and self.strike_value is None:
                 raise ValueError("strike_value required when strike_mode='strike'")
             if self.strike_mode in (

--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -37,6 +37,7 @@ class Leg(BaseModel):
     Batch mode legs (parent ``strategy_kind="batch"``):
       * ``segment="options"`` requires ``option_type`` and ``strike_mode``.
       * ``strike_mode="atm"`` / ``"spot_based"`` / ``"future_based"`` requires ``atm_offset``.
+      * ``strike_mode="atm_pct"`` requires ``atm_pct_value``.
       * ``strike_mode="strike"`` requires ``strike_value``.
       * ``strike_mode="premium_*"`` requires ``premium_value``.
 
@@ -75,6 +76,7 @@ class Leg(BaseModel):
     option_type: Optional[Literal["CE", "PE"]] = None
     strike_mode: Optional[Literal[
         "atm", "spot_based", "future_based", "strike",
+        "atm_pct",
         "premium_near", "premium_greater", "premium_lesser",
     ]] = None
     atm_offset: Optional[str] = Field(
@@ -83,6 +85,7 @@ class Leg(BaseModel):
         description="ATM, ATM+1, ATM-1, ITM2, OTM3, etc.",
     )
     strike_value: Optional[float] = Field(None, gt=0)
+    atm_pct_value: Optional[float] = Field(None, description="ATM +/- percentage for strike selection")
     premium_value: Optional[float] = Field(None, gt=0)
 
     # --- Signal-mode fields (None for batch-mode legs) ---
@@ -110,6 +113,8 @@ class Leg(BaseModel):
                 raise ValueError(
                     "atm_offset required when strike_mode is spot/future based"
                 )
+            if self.strike_mode == "atm_pct" and self.atm_pct_value is None:
+                raise ValueError("atm_pct_value required when strike_mode='atm_pct'")
             if self.strike_mode == "strike" and self.strike_value is None:
                 raise ValueError("strike_value required when strike_mode='strike'")
             if self.strike_mode in (

--- a/backend/services/option_symbol_service.py
+++ b/backend/services/option_symbol_service.py
@@ -199,6 +199,14 @@ def _apply_offset(atm: float, offset: str, option_type: str, strikes: list[float
     return strikes[target_idx]
 
 
+def _apply_atm_percent(atm: float, percent: float, strikes: list[float]) -> float | None:
+    """Return the tradable strike closest to ATM +/- percent of ATM."""
+    if not strikes:
+        return None
+    target = atm + (atm * percent / 100)
+    return min(strikes, key=lambda s: abs(s - target))
+
+
 def _format_strike(strike: float) -> str:
     return str(int(strike)) if strike == int(strike) else str(strike)
 

--- a/backend/services/option_symbol_service.py
+++ b/backend/services/option_symbol_service.py
@@ -215,6 +215,11 @@ def _apply_straddle_width(atm: float, straddle_premium: float, width: float, str
     return min(strikes, key=lambda s: abs(s - target))
 
 
+def _underlying_percent_premium(underlying_ltp: float, percent: float) -> float:
+    """Premium target equal to a percentage of the underlying reference price."""
+    return underlying_ltp * percent / 100
+
+
 def _format_strike(strike: float) -> str:
     return str(int(strike)) if strike == int(strike) else str(strike)
 

--- a/backend/services/option_symbol_service.py
+++ b/backend/services/option_symbol_service.py
@@ -207,6 +207,14 @@ def _apply_atm_percent(atm: float, percent: float, strikes: list[float]) -> floa
     return min(strikes, key=lambda s: abs(s - target))
 
 
+def _apply_straddle_width(atm: float, straddle_premium: float, width: float, strikes: list[float]) -> float | None:
+    """Return the tradable strike closest to ATM +/- straddle premium * width."""
+    if not strikes:
+        return None
+    target = atm + (straddle_premium * width)
+    return min(strikes, key=lambda s: abs(s - target))
+
+
 def _format_strike(strike: float) -> str:
     return str(int(strike)) if strike == int(strike) else str(strike)
 

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -199,6 +199,30 @@ def _resolve_leg(
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'ATM percent resolution failed')}")
         return data
 
+    if strike_mode == "straddle_width":
+        straddle_width_value = leg.get("straddle_width_value")
+        if straddle_width_value is None:
+            raise EngineError(
+                f"Leg {leg.get('id')}: straddle_width_value required when strike_mode=straddle_width"
+            )
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: straddle-width resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_straddle_width(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            width=float(straddle_width_value),
+            option_type=option_type,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'straddle-width resolution failed')}")
+        return data
+
     if strike_mode == "strike":
         strike_value = leg.get("strike_value")
         if strike_value is None:

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -223,6 +223,30 @@ def _resolve_leg(
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'straddle-width resolution failed')}")
         return data
 
+    if strike_mode == "underlying_pct":
+        underlying_pct_value = leg.get("underlying_pct_value")
+        if underlying_pct_value is None:
+            raise EngineError(
+                f"Leg {leg.get('id')}: underlying_pct_value required when strike_mode=underlying_pct"
+            )
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: underlying-percent resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_underlying_percent(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            percent=float(underlying_pct_value),
+            option_type=option_type,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'underlying-percent resolution failed')}")
+        return data
+
     if strike_mode == "strike":
         strike_value = leg.get("strike_value")
         if strike_value is None:

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -128,12 +128,12 @@ def _resolve_leg(
         }
 
     # Options
-    strike_mode = leg.get("strike_mode") or "atm"
+    strike_mode = leg.get("strike_mode") or "spot_based"
     option_type = leg.get("option_type")
     if not option_type:
         raise EngineError(f"Leg {leg.get('id')}: option_type required for options segment")
 
-    if strike_mode == "atm":
+    if strike_mode in ("atm", "spot_based"):
         atm_offset = leg.get("atm_offset") or "ATM"
         if not auth_token or not broker:
             # Without broker auth we can't fetch the underlying's LTP, which
@@ -157,6 +157,26 @@ def _resolve_leg(
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'ATM resolution failed')}")
         return data
 
+    if strike_mode == "future_based":
+        atm_offset = leg.get("atm_offset") or "ATM"
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: future-based resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_future_based(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            atm_offset=atm_offset,
+            option_type=option_type,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'future-based resolution failed')}")
+        return data
+
     if strike_mode == "strike":
         strike_value = leg.get("strike_value")
         if strike_value is None:
@@ -170,6 +190,31 @@ def _resolve_leg(
         )
         if not ok:
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'direct strike not found')}")
+        return data
+
+    if strike_mode in ("premium_near", "premium_greater", "premium_lesser"):
+        premium_value = leg.get("premium_value")
+        if premium_value is None:
+            raise EngineError(
+                f"Leg {leg.get('id')}: premium_value required when strike_mode={strike_mode}"
+            )
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: premium-based resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_premium_based(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            option_type=option_type,
+            premium_value=float(premium_value),
+            mode=strike_mode,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'premium-based resolution failed')}")
         return data
 
     raise EngineError(f"Leg {leg.get('id')}: unknown strike_mode '{strike_mode}'")

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -177,6 +177,28 @@ def _resolve_leg(
             raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'future-based resolution failed')}")
         return data
 
+    if strike_mode == "atm_pct":
+        atm_pct_value = leg.get("atm_pct_value")
+        if atm_pct_value is None:
+            raise EngineError(f"Leg {leg.get('id')}: atm_pct_value required when strike_mode=atm_pct")
+        if not auth_token or not broker:
+            raise EngineError(
+                f"Leg {leg.get('id')}: ATM percent resolution needs broker auth."
+            )
+        ok, data, _ = symbol_resolver.resolve_atm_percent(
+            underlying=underlying,
+            underlying_exchange=underlying_exchange,
+            expiry_date=resolved,
+            atm_percent=float(atm_pct_value),
+            option_type=option_type,
+            auth_token=auth_token,
+            broker=broker,
+            config=config,
+        )
+        if not ok:
+            raise EngineError(f"Leg {leg.get('id')}: {data.get('message', 'ATM percent resolution failed')}")
+        return data
+
     if strike_mode == "strike":
         strike_value = leg.get("strike_value")
         if strike_value is None:

--- a/backend/strategy/symbol_resolver.py
+++ b/backend/strategy/symbol_resolver.py
@@ -28,11 +28,14 @@ from typing import Any, Optional
 
 from backend.services.market_data_service import get_expiry_dates
 from backend.services.option_symbol_service import (
+    _fetch_available_strikes,
     _format_strike,
+    _find_near_month_futures,
     _lookup_option_in_db,
     _option_exchange_for,
     get_option_symbol,
 )
+from backend.services.quotes_service import get_multi_quotes_with_auth, get_quotes_with_auth
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +169,61 @@ def resolve_atm(
     )
 
 
+def resolve_future_based(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    atm_offset: str,
+    option_type: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Resolve ATM-relative options using the nearest FUT LTP as reference."""
+    base = underlying.strip().upper()
+    fut_exchange = option_exchange_for(underlying_exchange)
+    fut = _find_near_month_futures(base, fut_exchange)
+    if not fut:
+        return False, {
+            "status": "error",
+            "message": f"No FUT contract found for {base} on {fut_exchange}",
+        }, 404
+
+    ok, quote_data, status_code = get_quotes_with_auth(
+        symbol=fut["symbol"],
+        exchange=fut["exchange"],
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, {
+            "status": "error",
+            "message": (
+                f"Failed to fetch FUT LTP for {fut['symbol']}: "
+                f"{quote_data.get('message', 'unknown error')}"
+            ),
+        }, status_code
+
+    fut_ltp = quote_data.get("data", {}).get("ltp")
+    if fut_ltp is None:
+        return False, {"status": "error", "message": f"LTP not available for {fut['symbol']}"}, 500
+
+    expiry_compact = expiry_date.replace("-", "").upper()
+    return get_option_symbol(
+        underlying=underlying,
+        exchange=underlying_exchange,
+        expiry_date=expiry_compact,
+        offset=atm_offset,
+        option_type=option_type,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+        underlying_ltp=float(fut_ltp),
+    )
+
+
 def resolve_direct_strike(
     *,
     underlying: str,
@@ -211,6 +269,120 @@ def resolve_direct_strike(
         "strike": details["strike"],
         "expiry": details["expiry"],
         "underlying_ltp": None,  # not fetched in direct-strike mode
+    }, 200
+
+
+def _quote_ltp(row: dict[str, Any]) -> Optional[float]:
+    data = row.get("data") if isinstance(row.get("data"), dict) else row
+    value = data.get("ltp") if isinstance(data, dict) else None
+    if value is None:
+        value = row.get("ltp")
+    try:
+        ltp = float(value)
+    except (TypeError, ValueError):
+        return None
+    return ltp if ltp > 0 else None
+
+
+def _quote_symbol(row: dict[str, Any]) -> Optional[str]:
+    symbol = row.get("symbol")
+    if symbol:
+        return str(symbol)
+    data = row.get("data")
+    if isinstance(data, dict) and data.get("symbol"):
+        return str(data["symbol"])
+    return None
+
+
+def resolve_premium_based(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    option_type: str,
+    premium_value: float,
+    mode: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Pick the option whose live premium matches near/greater/lesser mode."""
+    base = underlying.strip().upper()
+    opt_exchange = option_exchange_for(underlying_exchange)
+    expiry_compact = expiry_date.replace("-", "").upper()
+    option_type_u = option_type.upper()
+    if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", expiry_compact):
+        return False, {"status": "error", "message": f"Invalid expiry: {expiry_date}"}, 400
+    if option_type_u not in ("CE", "PE"):
+        return False, {"status": "error", "message": "option_type must be CE or PE"}, 400
+
+    strikes = _fetch_available_strikes(base, expiry_compact, option_type_u, opt_exchange)
+    if not strikes:
+        return False, {
+            "status": "error",
+            "message": f"No strikes found for {base} {expiry_compact} on {opt_exchange}.",
+        }, 404
+
+    details_by_symbol: dict[str, dict[str, Any]] = {}
+    symbols_list = []
+    for strike in strikes:
+        symbol = f"{base}{expiry_compact}{_format_strike(strike)}{option_type_u}"
+        details = _lookup_option_in_db(symbol, opt_exchange)
+        if not details:
+            continue
+        details_by_symbol[details["symbol"]] = details
+        symbols_list.append({"symbol": details["symbol"], "exchange": details["exchange"]})
+
+    if not symbols_list:
+        return False, {
+            "status": "error",
+            "message": f"No tradable option symbols found for {base} {expiry_compact} {option_type_u}.",
+        }, 404
+
+    ok, quote_data, status_code = get_multi_quotes_with_auth(
+        symbols_list=symbols_list,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, quote_data, status_code
+
+    candidates = []
+    for row in quote_data.get("results", []):
+        symbol = _quote_symbol(row)
+        details = details_by_symbol.get(symbol)
+        ltp = _quote_ltp(row)
+        if not details or ltp is None:
+            continue
+        candidates.append((details, ltp))
+
+    if mode == "premium_greater":
+        candidates = [(d, l) for d, l in candidates if l >= premium_value]
+        key = lambda item: (item[1] - premium_value, item[0]["strike"])
+    elif mode == "premium_lesser":
+        candidates = [(d, l) for d, l in candidates if l <= premium_value]
+        key = lambda item: (premium_value - item[1], -float(item[0]["strike"]))
+    else:
+        key = lambda item: (abs(item[1] - premium_value), item[0]["strike"])
+
+    if not candidates:
+        return False, {
+            "status": "error",
+            "message": f"No option premium matched {mode.replace('_', ' ')} {premium_value}.",
+        }, 404
+
+    details, ltp = min(candidates, key=key)
+    return True, {
+        "status": "success",
+        "symbol": details["symbol"],
+        "exchange": details["exchange"],
+        "lotsize": details["lotsize"],
+        "tick_size": details["tick_size"],
+        "strike": details["strike"],
+        "expiry": details["expiry"],
+        "underlying_ltp": None,
+        "option_ltp": ltp,
     }, 200
 
 

--- a/backend/strategy/symbol_resolver.py
+++ b/backend/strategy/symbol_resolver.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 from backend.services.market_data_service import get_expiry_dates
 from backend.services.option_symbol_service import (
     _apply_atm_percent,
+    _apply_straddle_width,
     _fetch_available_strikes,
     _format_strike,
     _find_atm,
@@ -314,6 +315,138 @@ def resolve_atm_percent(
         "underlying_ltp": float(ltp),
         "atm_strike": atm,
         "atm_percent": atm_percent,
+    }, 200
+
+
+def resolve_straddle_width(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    width: float,
+    option_type: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Resolve an option strike at ATM +/- ATM straddle premium * width."""
+    base_symbol, embedded_expiry = _parse_underlying(underlying)
+    final_expiry = (expiry_date or embedded_expiry or "").replace("-", "").upper()
+    if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", final_expiry):
+        return False, {"status": "error", "message": f"Invalid expiry: {expiry_date}"}, 400
+
+    option_type_u = option_type.upper()
+    if option_type_u not in ("CE", "PE"):
+        return False, {"status": "error", "message": "option_type must be CE or PE"}, 400
+
+    quote_exchange = _quote_exchange_for(base_symbol, underlying_exchange)
+    options_exchange = option_exchange_for(quote_exchange)
+    if quote_exchange in ("NSE_INDEX", "BSE_INDEX", "NSE", "BSE"):
+        quote_symbol, quote_exchange_for_ltp = base_symbol, quote_exchange
+    elif embedded_expiry:
+        quote_symbol, quote_exchange_for_ltp = underlying.upper(), quote_exchange
+    else:
+        fut = _find_near_month_futures(base_symbol, quote_exchange)
+        if not fut:
+            return False, {
+                "status": "error",
+                "message": f"No FUT contract found for {base_symbol} on {quote_exchange}",
+            }, 404
+        quote_symbol, quote_exchange_for_ltp = fut["symbol"], fut["exchange"]
+
+    ok, quote_data, status_code = get_quotes_with_auth(
+        symbol=quote_symbol,
+        exchange=quote_exchange_for_ltp,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, {
+            "status": "error",
+            "message": f"Failed to fetch LTP for {quote_symbol}: {quote_data.get('message', 'unknown error')}",
+        }, status_code
+
+    ltp = quote_data.get("data", {}).get("ltp")
+    if ltp is None:
+        return False, {"status": "error", "message": f"LTP not available for {quote_symbol}"}, 500
+
+    strikes = _fetch_available_strikes(base_symbol, final_expiry, option_type_u, options_exchange)
+    if not strikes:
+        return False, {
+            "status": "error",
+            "message": f"No strikes found for {base_symbol} {final_expiry} on {options_exchange}.",
+        }, 404
+
+    atm = _find_atm(float(ltp), strikes)
+    if atm is None:
+        return False, {"status": "error", "message": "Could not determine ATM strike"}, 404
+
+    atm_symbols: list[dict[str, str]] = []
+    details_by_symbol: dict[str, dict[str, Any]] = {}
+    for atm_option_type in ("CE", "PE"):
+        symbol = f"{base_symbol}{final_expiry}{_format_strike(atm)}{atm_option_type}"
+        details = _lookup_option_in_db(symbol, options_exchange)
+        if not details:
+            return False, {
+                "status": "error",
+                "message": f"ATM {atm_option_type} option {symbol} not found on {options_exchange}.",
+            }, 404
+        details_by_symbol[details["symbol"]] = details
+        atm_symbols.append({"symbol": details["symbol"], "exchange": details["exchange"]})
+
+    ok, straddle_quotes, status_code = get_multi_quotes_with_auth(
+        symbols_list=atm_symbols,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, straddle_quotes, status_code
+
+    premiums: dict[str, float] = {}
+    for row in straddle_quotes.get("results", []):
+        symbol = _quote_symbol(row)
+        ltp_value = _quote_ltp(row)
+        details = details_by_symbol.get(symbol)
+        if not symbol or ltp_value is None or not details:
+            continue
+        suffix = "CE" if symbol.upper().endswith("CE") else "PE"
+        premiums[suffix] = ltp_value
+
+    if "CE" not in premiums or "PE" not in premiums:
+        return False, {
+            "status": "error",
+            "message": "ATM CE and PE premiums are required for straddle width selection.",
+        }, 404
+
+    straddle_premium = premiums["CE"] + premiums["PE"]
+    target_strike = _apply_straddle_width(atm, straddle_premium, width, strikes)
+    if target_strike is None:
+        return False, {"status": "error", "message": "Straddle width strike out of range"}, 400
+
+    option_symbol = f"{base_symbol}{final_expiry}{_format_strike(target_strike)}{option_type_u}"
+    details = _lookup_option_in_db(option_symbol, options_exchange)
+    if not details:
+        return False, {
+            "status": "error",
+            "message": f"Option {option_symbol} not found on {options_exchange}.",
+        }, 404
+
+    return True, {
+        "status": "success",
+        "symbol": details["symbol"],
+        "exchange": details["exchange"],
+        "lotsize": details["lotsize"],
+        "tick_size": details["tick_size"],
+        "strike": details["strike"],
+        "expiry": details["expiry"],
+        "underlying_ltp": float(ltp),
+        "atm_strike": atm,
+        "straddle_width": width,
+        "straddle_premium": straddle_premium,
+        "atm_ce_premium": premiums["CE"],
+        "atm_pe_premium": premiums["PE"],
     }, 200
 
 

--- a/backend/strategy/symbol_resolver.py
+++ b/backend/strategy/symbol_resolver.py
@@ -38,6 +38,7 @@ from backend.services.option_symbol_service import (
     _option_exchange_for,
     _parse_underlying,
     _quote_exchange_for,
+    _underlying_percent_premium,
     get_option_symbol,
 )
 from backend.services.quotes_service import get_multi_quotes_with_auth, get_quotes_with_auth
@@ -448,6 +449,78 @@ def resolve_straddle_width(
         "atm_ce_premium": premiums["CE"],
         "atm_pe_premium": premiums["PE"],
     }, 200
+
+
+def resolve_underlying_percent(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    percent: float,
+    option_type: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Pick the option whose premium is closest to percent of underlying LTP."""
+    base_symbol, embedded_expiry = _parse_underlying(underlying)
+    final_expiry = (expiry_date or embedded_expiry or "").replace("-", "").upper()
+    if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", final_expiry):
+        return False, {"status": "error", "message": f"Invalid expiry: {expiry_date}"}, 400
+
+    option_type_u = option_type.upper()
+    if option_type_u not in ("CE", "PE"):
+        return False, {"status": "error", "message": "option_type must be CE or PE"}, 400
+
+    quote_exchange = _quote_exchange_for(base_symbol, underlying_exchange)
+    if quote_exchange in ("NSE_INDEX", "BSE_INDEX", "NSE", "BSE"):
+        quote_symbol, quote_exchange_for_ltp = base_symbol, quote_exchange
+    elif embedded_expiry:
+        quote_symbol, quote_exchange_for_ltp = underlying.upper(), quote_exchange
+    else:
+        fut = _find_near_month_futures(base_symbol, quote_exchange)
+        if not fut:
+            return False, {
+                "status": "error",
+                "message": f"No FUT contract found for {base_symbol} on {quote_exchange}",
+            }, 404
+        quote_symbol, quote_exchange_for_ltp = fut["symbol"], fut["exchange"]
+
+    ok, quote_data, status_code = get_quotes_with_auth(
+        symbol=quote_symbol,
+        exchange=quote_exchange_for_ltp,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, {
+            "status": "error",
+            "message": f"Failed to fetch LTP for {quote_symbol}: {quote_data.get('message', 'unknown error')}",
+        }, status_code
+
+    ltp = quote_data.get("data", {}).get("ltp")
+    if ltp is None:
+        return False, {"status": "error", "message": f"LTP not available for {quote_symbol}"}, 500
+
+    target_premium = _underlying_percent_premium(float(ltp), percent)
+    ok, data, status_code = resolve_premium_based(
+        underlying=underlying,
+        underlying_exchange=underlying_exchange,
+        expiry_date=final_expiry,
+        option_type=option_type_u,
+        premium_value=target_premium,
+        mode="premium_near",
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, data, status_code
+    data["underlying_ltp"] = float(ltp)
+    data["underlying_percent"] = percent
+    data["target_premium"] = target_premium
+    return True, data, 200
 
 
 def resolve_direct_strike(

--- a/backend/strategy/symbol_resolver.py
+++ b/backend/strategy/symbol_resolver.py
@@ -28,11 +28,15 @@ from typing import Any, Optional
 
 from backend.services.market_data_service import get_expiry_dates
 from backend.services.option_symbol_service import (
+    _apply_atm_percent,
     _fetch_available_strikes,
     _format_strike,
+    _find_atm,
     _find_near_month_futures,
     _lookup_option_in_db,
     _option_exchange_for,
+    _parse_underlying,
+    _quote_exchange_for,
     get_option_symbol,
 )
 from backend.services.quotes_service import get_multi_quotes_with_auth, get_quotes_with_auth
@@ -222,6 +226,95 @@ def resolve_future_based(
         config=config,
         underlying_ltp=float(fut_ltp),
     )
+
+
+def resolve_atm_percent(
+    *,
+    underlying: str,
+    underlying_exchange: str,
+    expiry_date: str,
+    atm_percent: float,
+    option_type: str,
+    auth_token: str,
+    broker: str,
+    config: Optional[dict] = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """Resolve an option strike at ATM +/- percentage from the ATM strike."""
+    base_symbol, embedded_expiry = _parse_underlying(underlying)
+    final_expiry = (expiry_date or embedded_expiry or "").replace("-", "").upper()
+    if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", final_expiry):
+        return False, {"status": "error", "message": f"Invalid expiry: {expiry_date}"}, 400
+
+    option_type_u = option_type.upper()
+    if option_type_u not in ("CE", "PE"):
+        return False, {"status": "error", "message": "option_type must be CE or PE"}, 400
+
+    quote_exchange = _quote_exchange_for(base_symbol, underlying_exchange)
+    options_exchange = option_exchange_for(quote_exchange)
+    if quote_exchange in ("NSE_INDEX", "BSE_INDEX", "NSE", "BSE"):
+        quote_symbol, quote_exchange_for_ltp = base_symbol, quote_exchange
+    elif embedded_expiry:
+        quote_symbol, quote_exchange_for_ltp = underlying.upper(), quote_exchange
+    else:
+        fut = _find_near_month_futures(base_symbol, quote_exchange)
+        if not fut:
+            return False, {
+                "status": "error",
+                "message": f"No FUT contract found for {base_symbol} on {quote_exchange}",
+            }, 404
+        quote_symbol, quote_exchange_for_ltp = fut["symbol"], fut["exchange"]
+
+    ok, quote_data, status_code = get_quotes_with_auth(
+        symbol=quote_symbol,
+        exchange=quote_exchange_for_ltp,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    if not ok:
+        return False, {
+            "status": "error",
+            "message": f"Failed to fetch LTP for {quote_symbol}: {quote_data.get('message', 'unknown error')}",
+        }, status_code
+
+    ltp = quote_data.get("data", {}).get("ltp")
+    if ltp is None:
+        return False, {"status": "error", "message": f"LTP not available for {quote_symbol}"}, 500
+
+    strikes = _fetch_available_strikes(base_symbol, final_expiry, option_type_u, options_exchange)
+    if not strikes:
+        return False, {
+            "status": "error",
+            "message": f"No strikes found for {base_symbol} {final_expiry} on {options_exchange}.",
+        }, 404
+
+    atm = _find_atm(float(ltp), strikes)
+    if atm is None:
+        return False, {"status": "error", "message": "Could not determine ATM strike"}, 404
+    target_strike = _apply_atm_percent(atm, atm_percent, strikes)
+    if target_strike is None:
+        return False, {"status": "error", "message": "ATM percent strike out of range"}, 400
+
+    option_symbol = f"{base_symbol}{final_expiry}{_format_strike(target_strike)}{option_type_u}"
+    details = _lookup_option_in_db(option_symbol, options_exchange)
+    if not details:
+        return False, {
+            "status": "error",
+            "message": f"Option {option_symbol} not found on {options_exchange}.",
+        }, 404
+
+    return True, {
+        "status": "success",
+        "symbol": details["symbol"],
+        "exchange": details["exchange"],
+        "lotsize": details["lotsize"],
+        "tick_size": details["tick_size"],
+        "strike": details["strike"],
+        "expiry": details["expiry"],
+        "underlying_ltp": float(ltp),
+        "atm_strike": atm,
+        "atm_percent": atm_percent,
+    }, 200
 
 
 def resolve_direct_strike(

--- a/backend/test/test_atm_percent_strike_selection.py
+++ b/backend/test/test_atm_percent_strike_selection.py
@@ -1,0 +1,25 @@
+from backend.services.option_symbol_service import _apply_atm_percent
+
+
+def test_atm_percent_selects_closest_positive_call_strike():
+    strikes = [41700, 41800, 42100, 42200, 42400, 42600, 43000]
+
+    assert _apply_atm_percent(42400, 0.5, strikes) == 42600
+
+
+def test_atm_percent_selects_closest_positive_put_strike():
+    strikes = [41700, 41800, 42100, 42200, 42400, 42600, 43000]
+
+    assert _apply_atm_percent(42400, 1.5, strikes) == 43000
+
+
+def test_atm_percent_selects_closest_negative_call_strike():
+    strikes = [41700, 41800, 42100, 42200, 42400, 42600, 43000]
+
+    assert _apply_atm_percent(42400, -0.5, strikes) == 42200
+
+
+def test_atm_percent_selects_closest_negative_put_strike():
+    strikes = [41700, 41800, 42100, 42200, 42400, 42600, 43000]
+
+    assert _apply_atm_percent(42400, -1.5, strikes) == 41800

--- a/backend/test/test_straddle_width_strike_selection.py
+++ b/backend/test/test_straddle_width_strike_selection.py
@@ -1,0 +1,13 @@
+from backend.services.option_symbol_service import _apply_straddle_width
+
+
+def test_straddle_width_selects_closest_positive_strike():
+    strikes = [39600, 39800, 40000, 40200, 40400]
+
+    assert _apply_straddle_width(40000, 495, 0.5, strikes) == 40200
+
+
+def test_straddle_width_selects_closest_negative_strike():
+    strikes = [39600, 39800, 40000, 40200, 40400]
+
+    assert _apply_straddle_width(40000, 495, -0.5, strikes) == 39800

--- a/backend/test/test_underlying_percent_strike_selection.py
+++ b/backend/test/test_underlying_percent_strike_selection.py
@@ -1,0 +1,9 @@
+from backend.services.option_symbol_service import _underlying_percent_premium
+
+
+def test_underlying_percent_calculates_one_percent_target_premium():
+    assert round(_underlying_percent_premium(24622.15, 1), 2) == 246.22
+
+
+def test_underlying_percent_calculates_half_percent_target_premium():
+    assert round(_underlying_percent_premium(24622.15, 0.5), 2) == 123.11

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -30,7 +30,9 @@ export function Select({
     <SelectPrimitive.Root
       value={value}
       defaultValue={defaultValue}
-      onValueChange={onValueChange}
+      onValueChange={(nextValue) => {
+        if (nextValue !== null) onValueChange?.(nextValue);
+      }}
       disabled={disabled}
     >
       {children}

--- a/frontend/src/pages/Playground.tsx
+++ b/frontend/src/pages/Playground.tsx
@@ -487,7 +487,7 @@ export default function Playground() {
       } else {
         const q = searchQuery.toLowerCase();
         const filtered = eps.filter(
-          (ep) =>
+          (ep: Endpoint) =>
             ep.name.toLowerCase().includes(q) || ep.path.toLowerCase().includes(q),
         );
         if (filtered.length) acc[category] = filtered;

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -1788,6 +1788,8 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                             : "—"
                           : strikeMode === "future_based"
                             ? `Future Based (${leg.atm_offset ?? "ATM"})`
+                            : strikeMode === "atm_pct"
+                              ? `ATM ${Number(leg.atm_pct_value ?? 0) >= 0 ? "+" : ""}${leg.atm_pct_value ?? "—"}%`
                             : strikeMode === "premium_near"
                               ? `Premium near ${leg.premium_value ?? "—"}`
                               : strikeMode === "premium_greater"

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -2490,7 +2490,7 @@ export default function StrategyDetail() {
     queryKey: ["strategy-orders", numId],
     queryFn: () => listOrders(numId),
     enabled: Number.isFinite(numId) && numId > 0,
-    refetchInterval: (q) =>
+    refetchInterval: () =>
       strategyQuery.data?.status === "running" ? SAFETY_REFETCH_MS : false,
   });
 
@@ -2504,7 +2504,7 @@ export default function StrategyDetail() {
     queryKey: ["strategy-events", numId],
     queryFn: () => listEvents(numId, undefined, 200),
     enabled: Number.isFinite(numId) && numId > 0,
-    refetchInterval: (q) =>
+    refetchInterval: () =>
       strategyQuery.data?.status === "running" ? SAFETY_REFETCH_MS : false,
   });
 
@@ -2512,7 +2512,7 @@ export default function StrategyDetail() {
     queryKey: ["strategy-positions", numId],
     queryFn: () => listPositions(numId),
     enabled: Number.isFinite(numId) && numId > 0,
-    refetchInterval: (q) =>
+    refetchInterval: () =>
       strategyQuery.data?.status === "running" ? SAFETY_REFETCH_MS : false,
   });
 
@@ -2520,7 +2520,7 @@ export default function StrategyDetail() {
     queryKey: ["strategy-trades", numId],
     queryFn: () => listTrades(numId),
     enabled: Number.isFinite(numId) && numId > 0,
-    refetchInterval: (q) =>
+    refetchInterval: () =>
       strategyQuery.data?.status === "running" ? SAFETY_REFETCH_MS : false,
   });
 

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -1792,6 +1792,8 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                               ? `ATM ${Number(leg.atm_pct_value ?? 0) >= 0 ? "+" : ""}${leg.atm_pct_value ?? "—"}%`
                               : strikeMode === "straddle_width"
                                 ? `Straddle ${Number(leg.straddle_width_value ?? 0) >= 0 ? "+" : ""}${leg.straddle_width_value ?? "—"}`
+                                : strikeMode === "underlying_pct"
+                                  ? `${leg.underlying_pct_value ?? "—"}% of Underlying`
                             : strikeMode === "premium_near"
                               ? `Premium near ${leg.premium_value ?? "—"}`
                               : strikeMode === "premium_greater"

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -1776,14 +1776,25 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                 </thead>
                 <tbody>
                   {strategy.legs.map((leg) => {
+                    const strikeMode = leg.strike_mode === "atm"
+                      ? "spot_based"
+                      : leg.strike_mode;
                     const strikeText =
                       leg.segment !== "options"
                         ? "—"
-                        : leg.strike_mode === "strike"
+                        : strikeMode === "strike"
                           ? leg.strike_value != null
                             ? `${leg.strike_value}`
                             : "—"
-                          : `ATM (${leg.atm_offset ?? "ATM"})`;
+                          : strikeMode === "future_based"
+                            ? `Future Based (${leg.atm_offset ?? "ATM"})`
+                            : strikeMode === "premium_near"
+                              ? `Premium near ${leg.premium_value ?? "—"}`
+                              : strikeMode === "premium_greater"
+                                ? `Premium greater ${leg.premium_value ?? "—"}`
+                                : strikeMode === "premium_lesser"
+                                  ? `Premium lesser ${leg.premium_value ?? "—"}`
+                                  : `Spot Based (${leg.atm_offset ?? "ATM"})`;
                     return (
                       <tr key={leg.id} className="border-t">
                         <td className="px-2 py-1.5 font-mono">{leg.id}</td>

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -1790,6 +1790,8 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                             ? `Future Based (${leg.atm_offset ?? "ATM"})`
                             : strikeMode === "atm_pct"
                               ? `ATM ${Number(leg.atm_pct_value ?? 0) >= 0 ? "+" : ""}${leg.atm_pct_value ?? "—"}%`
+                              : strikeMode === "straddle_width"
+                                ? `Straddle ${Number(leg.straddle_width_value ?? 0) >= 0 ? "+" : ""}${leg.straddle_width_value ?? "—"}`
                             : strikeMode === "premium_near"
                               ? `Premium near ${leg.premium_value ?? "—"}`
                               : strikeMode === "premium_greater"

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -83,6 +83,7 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     strike_value: null,
     atm_pct_value: null,
     straddle_width_value: null,
+    underlying_pct_value: null,
     target_pts: null,
     sl_pts: null,
     trail: { x: 0, y: 0 },
@@ -120,6 +121,7 @@ function freshSignalLeg(id: number, tab: UniverseTab): Leg {
     strike_value: null,
     atm_pct_value: null,
     straddle_width_value: null,
+    underlying_pct_value: null,
     symbol: "",
     exchange: "",
     side: "both",
@@ -164,6 +166,7 @@ const STRIKE_MODES: Array<{ value: StrikeMode; label: string }> = [
   { value: "future_based", label: "Future Based" },
   { value: "atm_pct", label: "ATM +/- %" },
   { value: "straddle_width", label: "Straddle Width" },
+  { value: "underlying_pct", label: "% of Underlying" },
   { value: "strike", label: "Strike Price" },
   { value: "premium_near", label: "Premium near" },
   { value: "premium_greater", label: "Premium greater" },
@@ -184,7 +187,7 @@ function normalizeStrikeMode(mode: StrikeMode | null | undefined): StrikeMode {
 function strikeModePatch(
   leg: Leg,
   mode: StrikeMode | null,
-): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "atm_pct_value" | "straddle_width_value" | "premium_value"> {
+): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "atm_pct_value" | "straddle_width_value" | "underlying_pct_value" | "premium_value"> {
   if (!mode) {
     return {
       strike_mode: null,
@@ -192,6 +195,7 @@ function strikeModePatch(
       strike_value: null,
       atm_pct_value: null,
       straddle_width_value: null,
+      underlying_pct_value: null,
       premium_value: null,
     };
   }
@@ -202,6 +206,7 @@ function strikeModePatch(
     strike_value: normalized === "strike" ? leg.strike_value ?? null : null,
     atm_pct_value: normalized === "atm_pct" ? leg.atm_pct_value ?? null : null,
     straddle_width_value: normalized === "straddle_width" ? leg.straddle_width_value ?? null : null,
+    underlying_pct_value: normalized === "underlying_pct" ? leg.underlying_pct_value ?? null : null,
     premium_value: PREMIUM_MODES.has(normalized) ? leg.premium_value ?? null : null,
   };
 }
@@ -421,6 +426,24 @@ function LegCard({
                   onChange={(e) =>
                     update(
                       "straddle_width_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+              </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "underlying_pct" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">% of underlying</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.underlying_pct_value ?? ""}
+                  placeholder="e.g. 1 or 0.5"
+                  onChange={(e) =>
+                    update(
+                      "underlying_pct_value",
                       e.target.value === "" ? null : Number(e.target.value),
                     )
                   }
@@ -804,6 +827,24 @@ function SignalLegCard({
                   className="h-9 font-mono"
                 />
               </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "underlying_pct" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">% of underlying</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.underlying_pct_value ?? ""}
+                  placeholder="e.g. 1 or 0.5"
+                  onChange={(e) =>
+                    update(
+                      "underlying_pct_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+              </div>
             ) : (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Premium value</Label>
@@ -841,6 +882,7 @@ function SignalLegCard({
     </Card>
   );
 }
+
 
 
 

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -57,6 +57,7 @@ import {
   type StrategyKind,
   type StrategyType,
   type StrategyUpdate,
+  type StrikeMode,
   type UniverseTab,
 } from "@/types/strategy_module";
 import { cn } from "@/lib/utils";
@@ -77,7 +78,7 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     lots: 1,
     position: "S",
     option_type: "CE",
-    strike_mode: "atm",
+    strike_mode: "spot_based",
     atm_offset: "ATM",
     strike_value: null,
     target_pts: null,
@@ -90,8 +91,8 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
 /** Signal-mode leg defaults: cash for stocks (NSE), futures for MCX,
  *  options for index tabs (weekly_monthly / monthly_only — no spot
  *  trading on indices). The user can switch segment per-leg afterwards.
- *  Options legs ride the same option_type / strike_mode / atm_offset /
- *  strike_value pipeline as batch-mode; the engine resolves the actual
+ *  Options legs ride the same option_type / strike selection pipeline as
+ *  batch-mode; the engine resolves the actual
  *  contract at signal time from (leg.symbol, expiry rank, option fields). */
 function freshSignalLeg(id: number, tab: UniverseTab): Leg {
   const allowedSegs = TAB_SEGMENTS[tab];
@@ -112,7 +113,7 @@ function freshSignalLeg(id: number, tab: UniverseTab): Leg {
     lots: 1,
     position: "B",
     option_type: segment === "options" ? "CE" : null,
-    strike_mode: segment === "options" ? "atm" : null,
+    strike_mode: segment === "options" ? "spot_based" : null,
     atm_offset: segment === "options" ? "ATM" : null,
     strike_value: null,
     symbol: "",
@@ -154,6 +155,47 @@ function expiriesFor(tab: UniverseTab, segment: Segment): ExpiryRank[] {
   return TAB_EXPIRIES[tab];
 }
 
+const STRIKE_MODES: Array<{ value: StrikeMode; label: string }> = [
+  { value: "spot_based", label: "Spot Based" },
+  { value: "future_based", label: "Future Based" },
+  { value: "strike", label: "Strike Price" },
+  { value: "premium_near", label: "Premium near" },
+  { value: "premium_greater", label: "Premium greater" },
+  { value: "premium_lesser", label: "Premium lesser" },
+];
+
+const SPOT_OFFSET_MODES = new Set<StrikeMode>(["atm", "spot_based", "future_based"]);
+const PREMIUM_MODES = new Set<StrikeMode>([
+  "premium_near",
+  "premium_greater",
+  "premium_lesser",
+]);
+
+function normalizeStrikeMode(mode: StrikeMode | null | undefined): StrikeMode {
+  return mode === "atm" ? "spot_based" : mode ?? "spot_based";
+}
+
+function strikeModePatch(
+  leg: Leg,
+  mode: StrikeMode | null,
+): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "premium_value"> {
+  if (!mode) {
+    return {
+      strike_mode: null,
+      atm_offset: null,
+      strike_value: null,
+      premium_value: null,
+    };
+  }
+  const normalized = normalizeStrikeMode(mode);
+  return {
+    strike_mode: normalized,
+    atm_offset: SPOT_OFFSET_MODES.has(normalized) ? leg.atm_offset ?? "ATM" : null,
+    strike_value: normalized === "strike" ? leg.strike_value ?? null : null,
+    premium_value: PREMIUM_MODES.has(normalized) ? leg.premium_value ?? null : null,
+  };
+}
+
 function LegCard({
   leg,
   tab,
@@ -190,28 +232,13 @@ function LegCard({
               value={leg.segment}
               onChange={(e) => {
                 const seg = e.target.value as Segment;
-                // Resolve the NEW strike_mode first; the atm_offset /
-                // strike_value defaults must be evaluated against that
-                // (not against `leg.strike_mode`, which may be null after
-                // an earlier round-trip through a non-options segment).
-                // Without this, toggling off→on options leaves
-                // atm_offset=null while strike_mode='atm' and the schema
-                // rejects with "atm_offset required when strike_mode='atm'".
                 const nextStrikeMode =
-                  seg === "options" ? leg.strike_mode ?? "atm" : null;
+                  seg === "options" ? normalizeStrikeMode(leg.strike_mode) : null;
                 onChange({
                   ...leg,
                   segment: seg,
                   option_type: seg === "options" ? leg.option_type ?? "CE" : null,
-                  strike_mode: nextStrikeMode,
-                  atm_offset:
-                    nextStrikeMode === "atm"
-                      ? leg.atm_offset ?? "ATM"
-                      : null,
-                  strike_value:
-                    nextStrikeMode === "strike"
-                      ? leg.strike_value ?? null
-                      : null,
+                  ...strikeModePatch(leg, nextStrikeMode),
                 });
               }}
               className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
@@ -298,33 +325,25 @@ function LegCard({
 
             <div className="space-y-1.5">
               <Label className="text-xs uppercase">Strike mode</Label>
-              <div className="flex h-9 overflow-hidden rounded-md border border-input">
-                {(["atm", "strike"] as const).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => {
-                      onChange({
-                        ...leg,
-                        strike_mode: m,
-                        atm_offset: m === "atm" ? leg.atm_offset ?? "ATM" : null,
-                        strike_value: m === "strike" ? leg.strike_value ?? null : null,
-                      });
-                    }}
-                    className={cn(
-                      "flex-1 text-sm font-medium transition-colors",
-                      leg.strike_mode === m
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-background hover:bg-muted",
-                    )}
-                  >
-                    {m === "atm" ? "ATM-relative" : "Direct strike"}
-                  </button>
+              <select
+                value={normalizeStrikeMode(leg.strike_mode)}
+                onChange={(e) =>
+                  onChange({
+                    ...leg,
+                    ...strikeModePatch(leg, e.target.value as StrikeMode),
+                  })
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+              >
+                {STRIKE_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>
+                    {m.label}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
 
-            {leg.strike_mode === "atm" ? (
+            {SPOT_OFFSET_MODES.has(normalizeStrikeMode(leg.strike_mode)) ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike offset</Label>
                 <select
@@ -339,7 +358,7 @@ function LegCard({
                   ))}
                 </select>
               </div>
-            ) : (
+            ) : normalizeStrikeMode(leg.strike_mode) === "strike" ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike value</Label>
                 <div className="flex gap-2">
@@ -363,6 +382,24 @@ function LegCard({
                 <p className="text-xs text-muted-foreground">
                   Filtered by underlying + resolved expiry rank ({leg.expiry}).
                 </p>
+              </div>
+            ) : (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Premium value</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.premium_value ?? ""}
+                  placeholder="e.g. 100"
+                  onChange={(e) =>
+                    update(
+                      "premium_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
               </div>
             )}
           </div>
@@ -542,26 +579,15 @@ function SignalLegCard({
               value={leg.segment}
               onChange={(e) => {
                 const seg = e.target.value as Segment;
-                // Resolve the new strike_mode first and use it as the
-                // source of truth for the atm_offset / strike_value
-                // defaults — same race fix as the batch LegCard.
                 const nextStrikeMode =
-                  seg === "options" ? leg.strike_mode ?? "atm" : null;
+                  seg === "options" ? normalizeStrikeMode(leg.strike_mode) : null;
                 onChange({
                   ...leg,
                   segment: seg,
                   expiry:
                     seg === "cash" ? null : expiryChoices[0] ?? "current",
                   option_type: seg === "options" ? leg.option_type ?? "CE" : null,
-                  strike_mode: nextStrikeMode,
-                  atm_offset:
-                    nextStrikeMode === "atm"
-                      ? leg.atm_offset ?? "ATM"
-                      : null,
-                  strike_value:
-                    nextStrikeMode === "strike"
-                      ? leg.strike_value ?? null
-                      : null,
+                  ...strikeModePatch(leg, nextStrikeMode),
                 });
               }}
               className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
@@ -646,34 +672,25 @@ function SignalLegCard({
 
             <div className="space-y-1.5">
               <Label className="text-xs uppercase">Strike mode</Label>
-              <div className="flex h-9 overflow-hidden rounded-md border border-input">
-                {(["atm", "strike"] as const).map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => {
-                      onChange({
-                        ...leg,
-                        strike_mode: m,
-                        atm_offset: m === "atm" ? leg.atm_offset ?? "ATM" : null,
-                        strike_value:
-                          m === "strike" ? leg.strike_value ?? null : null,
-                      });
-                    }}
-                    className={cn(
-                      "flex-1 text-sm font-medium transition-colors",
-                      leg.strike_mode === m
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-background hover:bg-muted",
-                    )}
-                  >
-                    {m === "atm" ? "ATM-relative" : "Direct strike"}
-                  </button>
+              <select
+                value={normalizeStrikeMode(leg.strike_mode)}
+                onChange={(e) =>
+                  onChange({
+                    ...leg,
+                    ...strikeModePatch(leg, e.target.value as StrikeMode),
+                  })
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+              >
+                {STRIKE_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>
+                    {m.label}
+                  </option>
                 ))}
-              </div>
+              </select>
             </div>
 
-            {leg.strike_mode === "atm" ? (
+            {SPOT_OFFSET_MODES.has(normalizeStrikeMode(leg.strike_mode)) ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike offset</Label>
                 <select
@@ -688,7 +705,7 @@ function SignalLegCard({
                   ))}
                 </select>
               </div>
-            ) : (
+            ) : normalizeStrikeMode(leg.strike_mode) === "strike" ? (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Strike value</Label>
                 <Input
@@ -706,6 +723,28 @@ function SignalLegCard({
                 />
                 <p className="text-xs text-muted-foreground">
                   Engine looks up this strike on {leg.symbol || "<symbol>"}{" "}
+                  {leg.expiry} {leg.option_type} at signal time.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Premium value</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={leg.premium_value ?? ""}
+                  placeholder="e.g. 100"
+                  onChange={(e) =>
+                    update(
+                      "premium_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Engine picks the matching premium on {leg.symbol || "<symbol>"}{" "}
                   {leg.expiry} {leg.option_type} at signal time.
                 </p>
               </div>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -82,6 +82,7 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     atm_offset: "ATM",
     strike_value: null,
     atm_pct_value: null,
+    straddle_width_value: null,
     target_pts: null,
     sl_pts: null,
     trail: { x: 0, y: 0 },
@@ -118,6 +119,7 @@ function freshSignalLeg(id: number, tab: UniverseTab): Leg {
     atm_offset: segment === "options" ? "ATM" : null,
     strike_value: null,
     atm_pct_value: null,
+    straddle_width_value: null,
     symbol: "",
     exchange: "",
     side: "both",
@@ -161,6 +163,7 @@ const STRIKE_MODES: Array<{ value: StrikeMode; label: string }> = [
   { value: "spot_based", label: "Spot Based" },
   { value: "future_based", label: "Future Based" },
   { value: "atm_pct", label: "ATM +/- %" },
+  { value: "straddle_width", label: "Straddle Width" },
   { value: "strike", label: "Strike Price" },
   { value: "premium_near", label: "Premium near" },
   { value: "premium_greater", label: "Premium greater" },
@@ -181,13 +184,14 @@ function normalizeStrikeMode(mode: StrikeMode | null | undefined): StrikeMode {
 function strikeModePatch(
   leg: Leg,
   mode: StrikeMode | null,
-): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "atm_pct_value" | "premium_value"> {
+): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "atm_pct_value" | "straddle_width_value" | "premium_value"> {
   if (!mode) {
     return {
       strike_mode: null,
       atm_offset: null,
       strike_value: null,
       atm_pct_value: null,
+      straddle_width_value: null,
       premium_value: null,
     };
   }
@@ -197,6 +201,7 @@ function strikeModePatch(
     atm_offset: SPOT_OFFSET_MODES.has(normalized) ? leg.atm_offset ?? "ATM" : null,
     strike_value: normalized === "strike" ? leg.strike_value ?? null : null,
     atm_pct_value: normalized === "atm_pct" ? leg.atm_pct_value ?? null : null,
+    straddle_width_value: normalized === "straddle_width" ? leg.straddle_width_value ?? null : null,
     premium_value: PREMIUM_MODES.has(normalized) ? leg.premium_value ?? null : null,
   };
 }
@@ -399,6 +404,23 @@ function LegCard({
                   onChange={(e) =>
                     update(
                       "atm_pct_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+              </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "straddle_width" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Straddle width</Label>
+                <Input
+                  type="number"
+                  step={0.01}
+                  value={leg.straddle_width_value ?? ""}
+                  placeholder="e.g. 0.5 or -0.5"
+                  onChange={(e) =>
+                    update(
+                      "straddle_width_value",
                       e.target.value === "" ? null : Number(e.target.value),
                     )
                   }
@@ -765,6 +787,23 @@ function SignalLegCard({
                   className="h-9 font-mono"
                 />
               </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "straddle_width" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">Straddle width</Label>
+                <Input
+                  type="number"
+                  step={0.01}
+                  value={leg.straddle_width_value ?? ""}
+                  placeholder="e.g. 0.5 or -0.5"
+                  onChange={(e) =>
+                    update(
+                      "straddle_width_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+              </div>
             ) : (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Premium value</Label>
@@ -802,6 +841,7 @@ function SignalLegCard({
     </Card>
   );
 }
+
 
 
 interface StrikePickerProps {

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -269,7 +269,7 @@ function LegCard({
           <div className="space-y-1.5">
             <Label className="text-xs uppercase">Expiry</Label>
             <select
-              value={leg.expiry}
+              value={leg.expiry ?? "weekly"}
               onChange={(e) => update("expiry", e.target.value as ExpiryRank)}
               className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
             >
@@ -1797,7 +1797,7 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
           onOpenChange={(o) => !o && setStrikePickerLegIndex(null)}
           underlying={underlying}
           underlyingExchange={underlyingExchange}
-          expiryRank={legs[strikePickerLegIndex].expiry}
+          expiryRank={legs[strikePickerLegIndex].expiry ?? "weekly"}
           optionType={legs[strikePickerLegIndex].option_type ?? "CE"}
           selectedStrike={legs[strikePickerLegIndex].strike_value ?? null}
           onPick={(strike) => {

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -81,6 +81,7 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     strike_mode: "spot_based",
     atm_offset: "ATM",
     strike_value: null,
+    atm_pct_value: null,
     target_pts: null,
     sl_pts: null,
     trail: { x: 0, y: 0 },
@@ -116,6 +117,7 @@ function freshSignalLeg(id: number, tab: UniverseTab): Leg {
     strike_mode: segment === "options" ? "spot_based" : null,
     atm_offset: segment === "options" ? "ATM" : null,
     strike_value: null,
+    atm_pct_value: null,
     symbol: "",
     exchange: "",
     side: "both",
@@ -158,6 +160,7 @@ function expiriesFor(tab: UniverseTab, segment: Segment): ExpiryRank[] {
 const STRIKE_MODES: Array<{ value: StrikeMode; label: string }> = [
   { value: "spot_based", label: "Spot Based" },
   { value: "future_based", label: "Future Based" },
+  { value: "atm_pct", label: "ATM +/- %" },
   { value: "strike", label: "Strike Price" },
   { value: "premium_near", label: "Premium near" },
   { value: "premium_greater", label: "Premium greater" },
@@ -178,12 +181,13 @@ function normalizeStrikeMode(mode: StrikeMode | null | undefined): StrikeMode {
 function strikeModePatch(
   leg: Leg,
   mode: StrikeMode | null,
-): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "premium_value"> {
+): Pick<Leg, "strike_mode" | "atm_offset" | "strike_value" | "atm_pct_value" | "premium_value"> {
   if (!mode) {
     return {
       strike_mode: null,
       atm_offset: null,
       strike_value: null,
+      atm_pct_value: null,
       premium_value: null,
     };
   }
@@ -192,6 +196,7 @@ function strikeModePatch(
     strike_mode: normalized,
     atm_offset: SPOT_OFFSET_MODES.has(normalized) ? leg.atm_offset ?? "ATM" : null,
     strike_value: normalized === "strike" ? leg.strike_value ?? null : null,
+    atm_pct_value: normalized === "atm_pct" ? leg.atm_pct_value ?? null : null,
     premium_value: PREMIUM_MODES.has(normalized) ? leg.premium_value ?? null : null,
   };
 }
@@ -382,6 +387,23 @@ function LegCard({
                 <p className="text-xs text-muted-foreground">
                   Filtered by underlying + resolved expiry rank ({leg.expiry}).
                 </p>
+              </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "atm_pct" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">ATM +/- %</Label>
+                <Input
+                  type="number"
+                  step={0.01}
+                  value={leg.atm_pct_value ?? ""}
+                  placeholder="e.g. 0.5 or -0.5"
+                  onChange={(e) =>
+                    update(
+                      "atm_pct_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
               </div>
             ) : (
               <div className="space-y-1.5 sm:col-span-2">
@@ -726,6 +748,23 @@ function SignalLegCard({
                   {leg.expiry} {leg.option_type} at signal time.
                 </p>
               </div>
+            ) : normalizeStrikeMode(leg.strike_mode) === "atm_pct" ? (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label className="text-xs uppercase">ATM +/- %</Label>
+                <Input
+                  type="number"
+                  step={0.01}
+                  value={leg.atm_pct_value ?? ""}
+                  placeholder="e.g. 0.5 or -0.5"
+                  onChange={(e) =>
+                    update(
+                      "atm_pct_value",
+                      e.target.value === "" ? null : Number(e.target.value),
+                    )
+                  }
+                  className="h-9 font-mono"
+                />
+              </div>
             ) : (
               <div className="space-y-1.5 sm:col-span-2">
                 <Label className="text-xs uppercase">Premium value</Label>
@@ -763,6 +802,7 @@ function SignalLegCard({
     </Card>
   );
 }
+
 
 interface StrikePickerProps {
   open: boolean;

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -46,6 +46,7 @@ export type StrikeMode =
   | "future_based"
   | "atm_pct"
   | "straddle_width"
+  | "underlying_pct"
   | "strike"
   | "premium_near"
   | "premium_greater"
@@ -106,6 +107,7 @@ export interface Leg {
   strike_value?: number | null;
   atm_pct_value?: number | null;
   straddle_width_value?: number | null;
+  underlying_pct_value?: number | null;
   premium_value?: number | null;
 
   // --- Signal-mode fields (null/undefined for batch-mode legs) ---

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -44,6 +44,7 @@ export type StrikeMode =
   | "atm"
   | "spot_based"
   | "future_based"
+  | "atm_pct"
   | "strike"
   | "premium_near"
   | "premium_greater"
@@ -102,6 +103,7 @@ export interface Leg {
   strike_mode?: StrikeMode | null;
   atm_offset?: string | null;
   strike_value?: number | null;
+  atm_pct_value?: number | null;
   premium_value?: number | null;
 
   // --- Signal-mode fields (null/undefined for batch-mode legs) ---

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -45,6 +45,7 @@ export type StrikeMode =
   | "spot_based"
   | "future_based"
   | "atm_pct"
+  | "straddle_width"
   | "strike"
   | "premium_near"
   | "premium_greater"
@@ -104,6 +105,7 @@ export interface Leg {
   atm_offset?: string | null;
   strike_value?: number | null;
   atm_pct_value?: number | null;
+  straddle_width_value?: number | null;
   premium_value?: number | null;
 
   // --- Signal-mode fields (null/undefined for batch-mode legs) ---

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -40,7 +40,14 @@ export type ExpiryRank =
   | "monthly"
   | "current"
   | "next";
-export type StrikeMode = "atm" | "strike";
+export type StrikeMode =
+  | "atm"
+  | "spot_based"
+  | "future_based"
+  | "strike"
+  | "premium_near"
+  | "premium_greater"
+  | "premium_lesser";
 export type Weekday = "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "SUN";
 
 /**
@@ -95,6 +102,7 @@ export interface Leg {
   strike_mode?: StrikeMode | null;
   atm_offset?: string | null;
   strike_value?: number | null;
+  premium_value?: number | null;
 
   // --- Signal-mode fields (null/undefined for batch-mode legs) ---
   symbol?: string | null;


### PR DESCRIPTION
## Summary
- Add ATM +/- % strike selection.
- Add Straddle Width strike selection using ATM CE + ATM PE premium.
- Add % of Underlying strike selection using the option premium closest to a percentage of the underlying reference price.

## Scope
- Entry logic only.
- No adjustment-builder changes are included.
- No Move Stoploss to Cost changes are included.

## Validation
- `.venv/bin/python -m py_compile backend/services/option_symbol_service.py backend/strategy/symbol_resolver.py backend/strategy/engine.py backend/schemas/strategy_module.py`
- `.venv/bin/python -m pytest backend/test/test_atm_percent_strike_selection.py backend/test/test_straddle_width_strike_selection.py backend/test/test_underlying_percent_strike_selection.py`
- `git diff --check codex/advanced-strike-modes..HEAD`

## Known build note
- `npm run build` is currently blocked by existing TypeScript errors outside this entry-mode diff, including `frontend/src/components/ui/select.tsx`, `frontend/src/pages/Playground.tsx`, and existing strategy page type issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds advanced strike selection modes for entry logic—ATM +/- %, Straddle Width, % of underlying, premium-based targets, and future-based ATM—across engine, schema, tests, and UI. Default strike mode is now `spot_based` (backward compatible with legacy `atm`).

- **New Features**
  - Backend: new modes `spot_based`, `future_based`, `atm_pct`, `straddle_width`, `underlying_pct`, `strike`, and `premium_*` (`premium_near`, `premium_greater`, `premium_lesser`); validation for `atm_pct_value`, `straddle_width_value`, `underlying_pct_value`, `premium_value`; engine default set to `spot_based`; resolvers for future-based, ATM %, straddle width, underlying %, and premium-based; unit tests for ATM %, straddle width, and underlying % helpers.
  - Frontend: Wizard/Detail support all modes with inputs and clear leg-summary labels; UI normalizes legacy `atm` to `spot_based`.

- **Bug Fixes**
  - Unblocked branch frontend build with TypeScript fixes: guarded `Select` `onValueChange`, typed `Playground` filter, defaulted expiry values in Strategy pages, cleaned `refetchInterval` usage, and expanded `strategy_module` types.

<sup>Written for commit 15f183ddcbd4d13c12c36b487b876c72d40d43d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openbull/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

