### PR TITLE
Add underlying based entries and reentry

### DIFF
--- a/backend/schemas/strategy_module.py
+++ b/backend/schemas/strategy_module.py
@@ -28,6 +28,34 @@ class TrailConfig(BaseModel):
     y: float = Field(0, ge=0, description="Trail step (pts) once armed")
 
 
+class UnderlyingTriggerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operator: Literal[
+        "equal_to",
+        "is_above",
+        "is_below",
+        "equal_or_above",
+        "equal_or_below",
+    ]
+    value: float = Field(..., gt=0)
+
+
+class UnderlyingRiskConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sl_pts: Optional[float] = Field(None, ge=0)
+    target_pts: Optional[float] = Field(None, ge=0)
+
+
+class ReEntryConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["reentry", "recost", "reexecute"] = "reentry"
+    max_count: int = Field(0, ge=0, le=20)
+    on: Literal["sl", "target", "sl_or_target"] = "sl_or_target"
+
+
 class Leg(BaseModel):
     """One leg in a strategy.
 
@@ -89,6 +117,9 @@ class Leg(BaseModel):
     target_pts: Optional[float] = Field(None, ge=0)
     sl_pts: Optional[float] = Field(None, ge=0)
     trail: TrailConfig = Field(default_factory=TrailConfig)
+    underlying_entry: Optional[UnderlyingTriggerConfig] = None
+    underlying_risk: Optional[UnderlyingRiskConfig] = None
+    reentry: Optional[ReEntryConfig] = None
 
     momentum: Optional[dict] = Field(default=None, description="v1 stub — not evaluated")
 

--- a/backend/strategy/engine.py
+++ b/backend/strategy/engine.py
@@ -185,6 +185,87 @@ def _exit_action(position: str) -> str:
     return "SELL" if position == "B" else "BUY"
 
 
+async def _place_resolved_entry(
+    db: AsyncSession,
+    *,
+    strategy: SmStrategy,
+    run: SmStrategyRun,
+    resolved_leg: dict[str, Any],
+    mode: str,
+    broker: str,
+    auth_token: Optional[str],
+    config: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    """Place one already-resolved batch-mode leg entry order."""
+    action = _entry_action(resolved_leg["position"])
+    qty = int(resolved_leg["lots"]) * int(resolved_leg["lotsize"])
+    order_data = {
+        "symbol": resolved_leg["symbol"],
+        "exchange": resolved_leg["exchange"],
+        "action": action,
+        "quantity": str(qty),
+        "pricetype": strategy.pricetype or "MARKET",
+        "product": strategy.product or "NRML",
+        "price": "0",
+        "trigger_price": "0",
+        "strategy": strategy.name,
+    }
+    ok, response, _status = dispatch_order(
+        mode=mode,
+        user_id=strategy.user_id,
+        order_data=order_data,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+    )
+    broker_order_id = response.get("orderid") if isinstance(response, dict) else None
+
+    order_row = await repo.record_order(
+        db,
+        run_id=run.id,
+        leg_id=resolved_leg["leg_id"],
+        kind="entry",
+        symbol=resolved_leg["symbol"],
+        exchange=resolved_leg["exchange"],
+        action=action,
+        qty=qty,
+        pricetype=strategy.pricetype or "MARKET",
+        broker_order_id=broker_order_id,
+        status="open" if ok else "rejected",
+        reject_reason=None if ok else (
+            response.get("message", "rejected")
+            if isinstance(response, dict) else "rejected"
+        ),
+    )
+    if ok:
+        try:
+            await reconcile_order_fill(
+                db, order_row=order_row, mode=mode,
+                user_id=strategy.user_id,
+                broker=broker, auth_token=auth_token,
+            )
+        except Exception:
+            logger.exception("Fill recon failed for entry order %s", order_row.id)
+    repo.emit_leg_entry_placed(
+        user_id=strategy.user_id,
+        strategy_id=strategy.id,
+        run_id=run.id,
+        leg_id=resolved_leg["leg_id"],
+        symbol=resolved_leg["symbol"],
+        action=action,
+        qty=qty,
+        broker_order_id=broker_order_id,
+    )
+    return {
+        **resolved_leg,
+        "qty": qty,
+        "order_id": order_row.id,
+        "broker_order_id": broker_order_id,
+        "status": order_row.status,
+        "reject_reason": order_row.reject_reason,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle: start
 # ---------------------------------------------------------------------------
@@ -279,6 +360,9 @@ async def start_run(
             "tick_size": r["tick_size"],
             "strike": r.get("strike"),
             "expiry": r.get("expiry"),
+            "underlying_entry": leg.get("underlying_entry"),
+            "underlying_risk": leg.get("underlying_risk"),
+            "reentry": leg.get("reentry"),
         })
 
     # Open a run row first — so any failure mid-placement is logged against
@@ -290,92 +374,47 @@ async def start_run(
     # Place entry orders BUY-before-SELL — same convention as
     # options_multiorder_service. Avoids margin spikes on credit spreads
     # where the long leg should fund the short leg's margin.
-    buy_legs = [r for r in resolved_legs if r["position"] == "B"]
-    sell_legs = [r for r in resolved_legs if r["position"] == "S"]
+    immediate_legs = [r for r in resolved_legs if not r.get("underlying_entry")]
+    delayed_legs = [r for r in resolved_legs if r.get("underlying_entry")]
+    buy_legs = [r for r in immediate_legs if r["position"] == "B"]
+    sell_legs = [r for r in immediate_legs if r["position"] == "S"]
 
     leg_summaries: list[dict[str, Any]] = []
     placement_errors: list[str] = []
 
     for r in buy_legs + sell_legs:
-        action = _entry_action(r["position"])
-        qty = int(r["lots"]) * int(r["lotsize"])
-        order_data = {
-            "symbol": r["symbol"],
-            "exchange": r["exchange"],
-            "action": action,
-            "quantity": str(qty),
-            "pricetype": strategy.pricetype or "MARKET",
-            "product": strategy.product or "NRML",
-            "price": "0",
-            "trigger_price": "0",
-            "strategy": strategy.name,
-        }
-        ok, response, _status = dispatch_order(
+        leg_summary = await _place_resolved_entry(
+            db,
+            strategy=strategy,
+            run=run,
+            resolved_leg=r,
             mode=mode,
-            user_id=strategy.user_id,
-            order_data=order_data,
-            auth_token=auth_token,
             broker=broker,
+            auth_token=auth_token,
             config=config,
         )
-        broker_order_id = response.get("orderid") if isinstance(response, dict) else None
-
-        order_row = await repo.record_order(
-            db,
-            run_id=run.id,
-            leg_id=r["leg_id"],
-            kind="entry",
-            symbol=r["symbol"],
-            exchange=r["exchange"],
-            action=action,
-            qty=qty,
-            pricetype=strategy.pricetype or "MARKET",
-            broker_order_id=broker_order_id,
-            status="open" if ok else "rejected",
-            reject_reason=None if ok else response.get("message", "rejected"),
-        )
-        # Reconcile against sandbox/broker immediately so the order's
-        # actual fill price + status are on the row before the engine
-        # emits the audit event. Without this the orderbook UI sticks
-        # at 'open' and Live P&L has nothing to compute against.
-        if ok:
-            try:
-                await reconcile_order_fill(
-                    db, order_row=order_row, mode=mode,
-                    user_id=strategy.user_id,
-                    broker=broker, auth_token=auth_token,
-                )
-            except Exception:
-                logger.exception(
-                    "Fill recon failed for entry order %s", order_row.id,
-                )
-        repo.emit_leg_entry_placed(
-            user_id=strategy.user_id,
-            strategy_id=strategy.id,
-            run_id=run.id,
-            leg_id=r["leg_id"],
-            symbol=r["symbol"],
-            action=action,
-            qty=qty,
-            broker_order_id=broker_order_id,
-        )
+        leg_summaries.append(leg_summary)
+        if leg_summary["status"] == "rejected":
+            placement_errors.append(
+                f"leg {r['leg_id']} ({r['symbol']}): {leg_summary.get('reject_reason') or 'rejected'}"
+            )
+    for r in delayed_legs:
         leg_summaries.append({
             **r,
-            "qty": qty,
-            "order_id": order_row.id,
-            "broker_order_id": broker_order_id,
-            "status": order_row.status,
-            "reject_reason": order_row.reject_reason,
+            "qty": int(r["lots"]) * int(r["lotsize"]),
+            "order_id": None,
+            "broker_order_id": None,
+            "status": "configured",
+            "reject_reason": None,
         })
-        if not ok:
-            placement_errors.append(
-                f"leg {r['leg_id']} ({r['symbol']}): {response.get('message', 'rejected')}"
-            )
 
     # If every leg failed to place, the run is wedged — finalize as 'error'.
     # If only some failed, leave the run running so the user can square off
     # what did fill from the UI; log the partial failure prominently.
-    all_failed = all(s["status"] == "rejected" for s in leg_summaries)
+    all_failed = bool(immediate_legs) and not delayed_legs and all(
+        s["status"] == "rejected" for s in leg_summaries
+        if not s.get("underlying_entry")
+    )
     if all_failed:
         await repo.finalize_run(
             db, run=run, strategy=strategy, stop_reason="error",
@@ -433,6 +472,8 @@ async def start_run(
             if ls.get("status") != "rejected"
             and ls.get("symbol") and ls.get("exchange")
         })
+        if any(ls.get("underlying_entry") or ls.get("underlying_risk") for ls in leg_summaries):
+            symbols.append((strategy.underlying_exchange, strategy.underlying))
         tick_feed.add_run_subscriptions(run.id, symbols)
     except Exception:
         logger.exception("Failed to subscribe ticks for run %d", run.id)
@@ -751,6 +792,118 @@ async def _finalize_run_if_all_flat(
     except Exception:
         logger.exception("Failed to unsubscribe ticks for run %d", run.id)
     return True
+
+
+async def enter_batch_leg_for_run(
+    db: AsyncSession,
+    *,
+    strategy: SmStrategy,
+    run: SmStrategyRun,
+    leg_id: int,
+    mode: str,
+    broker: str,
+    auth_token: Optional[str],
+    config: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    """Open one batch-mode leg inside an existing run.
+
+    Used by underlying wait-and-trade and re-entry/re-execute rules. The
+    regular start path opens immediate legs; this function opens a configured
+    or previously closed leg without finalizing/restarting the run.
+    """
+    leg_config = next(
+        (leg for leg in (strategy.legs or []) if int(leg.get("id") or 0) == leg_id),
+        None,
+    )
+    if leg_config is None:
+        raise EngineError(f"Leg {leg_id}: config not found")
+    resolved = _resolve_leg(
+        leg_config,
+        underlying=strategy.underlying,
+        underlying_exchange=strategy.underlying_exchange,
+        auth_token=auth_token,
+        broker=broker,
+        config=config,
+        expiry_dates_cache={},
+    )
+    resolved_leg = {
+        "leg_id": leg_config["id"],
+        "position": leg_config["position"],
+        "lots": leg_config["lots"],
+        "symbol": resolved["symbol"],
+        "exchange": resolved["exchange"],
+        "lotsize": resolved["lotsize"],
+        "tick_size": resolved["tick_size"],
+        "strike": resolved.get("strike"),
+        "expiry": resolved.get("expiry"),
+        "underlying_entry": leg_config.get("underlying_entry"),
+        "underlying_risk": leg_config.get("underlying_risk"),
+        "reentry": leg_config.get("reentry"),
+    }
+    summary = await _place_resolved_entry(
+        db,
+        strategy=strategy,
+        run=run,
+        resolved_leg=resolved_leg,
+        mode=mode,
+        broker=broker,
+        auth_token=auth_token,
+        config=config,
+    )
+    if summary.get("status") == "rejected":
+        return summary
+
+    order_row = await db.get(SmStrategyOrder, summary["order_id"])
+    async with state_module.get_state_lock(run.id):
+        state = await state_module.get_run_state(run.id)
+        if state is not None:
+            leg_state = (state.setdefault("legs", {})).setdefault(str(leg_id), {})
+            leg_state.update({
+                "leg_id": leg_id,
+                "position": leg_config.get("position"),
+                "lots": leg_config.get("lots"),
+                "symbol": summary.get("symbol"),
+                "exchange": summary.get("exchange"),
+                "qty": summary.get("qty"),
+                "entry_order_id": summary.get("order_id"),
+                "entry_status": summary.get("status"),
+                "entry_avg": (
+                    float(order_row.avg_fill_price)
+                    if order_row is not None and order_row.avg_fill_price is not None
+                    else leg_state.get("entry_avg")
+                ),
+                "ltp": None,
+                "mtm": 0.0,
+                "status": "open",
+                "exit_order_id": None,
+                "exit_kind": None,
+                "effective_sl": None,
+                "effective_target": None,
+                "underlying_entry": leg_config.get("underlying_entry"),
+                "underlying_risk": leg_config.get("underlying_risk"),
+                "reentry": leg_config.get("reentry"),
+                "trail_active": False,
+                "favorable_peak": 0.0,
+            })
+            await state_module.hydrate_run_state(run.id, state)
+
+    if order_row is not None and order_row.avg_fill_price is not None:
+        await _apply_fill_to_state(
+            run.id,
+            leg_id=leg_id,
+            order_kind="entry",
+            avg_fill_price=float(order_row.avg_fill_price),
+            filled_qty=int(order_row.filled_qty or order_row.qty),
+            strategy_legs=strategy.legs or [],
+        )
+    try:
+        tick_feed.add_run_subscriptions(
+            run.id,
+            [(summary["exchange"], summary["symbol"])],
+        )
+    except Exception:
+        logger.exception("enter_batch_leg_for_run: failed to subscribe ticks")
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -1975,6 +2128,12 @@ async def _apply_fill_to_state(
         leg["entry_avg"] = avg_fill_price
         leg["qty"] = filled_qty
         leg["status"] = "open"
+        leg["entry_underlying_ltp"] = state.get("underlying_ltp")
+        leg["entry_count"] = int(leg.get("entry_count") or 0) + 1
+        leg["effective_sl"] = None
+        leg["effective_target"] = None
+        leg["trail_active"] = False
+        leg["favorable_peak"] = 0.0
         # For signal-mode legs the current_side has already been set by
         # enter_leg before the dispatch; for batch-mode legs we look at
         # the per-leg config's 'position' (B/S) to derive the side.
@@ -1999,6 +2158,7 @@ async def _apply_fill_to_state(
         leg["status"] = "closed"
         leg["current_side"] = None
         leg["mtm"] = 0.0  # closed legs contribute 0 to unrealized
+        leg["last_exit_price"] = avg_fill_price
 
     # Recompute strategy-level aggregates.
     realized_total = 0.0

--- a/backend/strategy/recovery.py
+++ b/backend/strategy/recovery.py
@@ -312,6 +312,11 @@ async def _recover_run(db: AsyncSession, run: SmStrategyRun) -> None:
         exch = leg.get("exchange")
         if sym and exch:
             open_leg_symbols.append((exch, sym))
+    if any(
+        leg.get("underlying_entry") or leg.get("underlying_risk")
+        for leg in state.get("legs", {}).values()
+    ):
+        open_leg_symbols.append((strategy.underlying_exchange, strategy.underlying))
     if open_leg_symbols:
         try:
             tick_feed.add_run_subscriptions(run.id, open_leg_symbols)

--- a/backend/strategy/state.py
+++ b/backend/strategy/state.py
@@ -93,13 +93,22 @@ def _build_initial_state(
             "entry_avg": None,
             "ltp": None,
             "mtm": 0.0,
-            "status": "rejected" if entry and entry["status"] == "rejected" else (
-                "open" if entry else "configured"
+            "status": (
+                "rejected" if entry and entry["status"] == "rejected"
+                else "open" if entry and entry["status"] == "open"
+                else "configured"
             ),
             "exit_order_id": None,
             "exit_kind": None,
             "effective_sl": None,
             "effective_target": None,
+            "underlying_entry": leg.get("underlying_entry"),
+            "underlying_risk": leg.get("underlying_risk"),
+            "reentry": leg.get("reentry"),
+            "entry_count": 1 if entry and entry.get("status") == "open" else 0,
+            "reentry_count": 0,
+            "last_exit_kind": None,
+            "last_exit_price": None,
             "trail_active": False,
             "favorable_peak": 0.0,
         }

--- a/backend/strategy/tick_processor.py
+++ b/backend/strategy/tick_processor.py
@@ -143,6 +143,8 @@ async def _process_tick_for_run(
         return
 
     triggered_exits: list[tuple[int, str]] = []
+    delayed_entries: list[int] = []
+    reentries: list[int] = []
     stop_reason: Optional[str] = None
 
     # Serialize state mutations against the engine's close-leg / exit paths.
@@ -157,6 +159,76 @@ async def _process_tick_for_run(
         if state is None:
             return
 
+        is_underlying_tick = (
+            exchange == strategy_row.underlying_exchange
+            and symbol == strategy_row.underlying
+        )
+
+        if is_underlying_tick:
+            state["underlying_ltp"] = ltp
+            state_changed = True
+            for lid, leg in (state.get("legs") or {}).items():
+                leg_id = int(lid)
+                if leg.get("status") == "configured":
+                    trigger = leg.get("underlying_entry")
+                    if trigger and _compare_trigger(
+                        ltp,
+                        trigger.get("operator"),
+                        float(trigger.get("value") or 0),
+                    ):
+                        leg["underlying_entry_fired_at"] = ltp
+                        leg["status"] = "pending_entry"
+                        delayed_entries.append(leg_id)
+                        state_changed = True
+                    continue
+                if leg.get("status") != "open":
+                    continue
+                risk_cfg = leg.get("underlying_risk") or {}
+                if not risk_cfg:
+                    continue
+                entry_underlying = leg.get("entry_underlying_ltp")
+                if entry_underlying is None:
+                    leg["entry_underlying_ltp"] = ltp
+                    state_changed = True
+                    continue
+                position = leg.get("position")
+                move = (
+                    ltp - float(entry_underlying)
+                    if position == "B"
+                    else float(entry_underlying) - ltp
+                )
+                sl_pts = risk_cfg.get("sl_pts")
+                target_pts = risk_cfg.get("target_pts")
+                if sl_pts and move <= -abs(float(sl_pts)):
+                    triggered_exits.append((leg_id, "exit_underlying_sl"))
+                    leg["last_exit_kind"] = "sl"
+                    state_changed = True
+                elif target_pts and move >= abs(float(target_pts)):
+                    triggered_exits.append((leg_id, "exit_underlying_target"))
+                    leg["last_exit_kind"] = "target"
+                    state_changed = True
+
+        waiting_reentries: list[int] = []
+        for lid, leg in (state.get("legs") or {}).items():
+            if leg.get("status") != "waiting_reentry":
+                continue
+            if leg.get("symbol") != symbol or leg.get("exchange") != exchange:
+                continue
+            entry_avg = leg.get("entry_avg")
+            exit_avg = leg.get("last_exit_price")
+            if entry_avg is None or exit_avg is None:
+                continue
+            entry_f = float(entry_avg)
+            exit_f = float(exit_avg)
+            if (
+                (exit_f > entry_f and ltp <= entry_f)
+                or (exit_f < entry_f and ltp >= entry_f)
+                or exit_f == entry_f
+            ):
+                leg["status"] = "pending_entry"
+                waiting_reentries.append(int(lid))
+                state_changed = True
+
         # Find every leg matching this symbol that's still open.
         matched_legs: list[tuple[str, dict]] = [
             (lid, leg) for lid, leg in state.get("legs", {}).items()
@@ -164,7 +236,7 @@ async def _process_tick_for_run(
             and leg.get("symbol") == symbol
             and leg.get("exchange") == exchange
         ]
-        if not matched_legs:
+        if not matched_legs and not is_underlying_tick and not waiting_reentries:
             return
 
         state_changed = False
@@ -207,9 +279,11 @@ async def _process_tick_for_run(
                 )
                 if outcome.triggered == "sl":
                     triggered_exits.append((int(lid), "exit_sl"))
+                    leg["last_exit_kind"] = "sl"
                     sl_leg_ids_this_tick.append(int(lid))
                 elif outcome.triggered == "target":
                     triggered_exits.append((int(lid), "exit_target"))
+                    leg["last_exit_kind"] = "target"
 
         # ---- Cross-cutting: Trail-SL-to-entry ----
         if (
@@ -281,6 +355,12 @@ async def _process_tick_for_run(
     # Runs outside the state lock so engine._exit_legs can re-acquire it.
     for leg_id, exit_kind in triggered_exits:
         await _trigger_exit(run_id, leg_id, exit_kind)
+        if exit_kind in {"exit_sl", "exit_target", "exit_underlying_sl", "exit_underlying_target"}:
+            if await _should_reenter(run_id, leg_id, exit_kind):
+                reentries.append(leg_id)
+
+    for leg_id in delayed_entries + reentries + waiting_reentries:
+        await _trigger_entry(run_id, leg_id)
 
     # If a strategy-level rule triggered, close every still-open leg via
     # engine.stop_run and finalize the run with the right stop_reason.
@@ -443,6 +523,99 @@ def _broadcast_delta(
     })
 
 
+def _compare_trigger(ltp: float, operator: Optional[str], value: float) -> bool:
+    if operator == "equal_to":
+        return ltp == value
+    if operator == "is_above":
+        return ltp > value
+    if operator == "is_below":
+        return ltp < value
+    if operator == "equal_or_above":
+        return ltp >= value
+    if operator == "equal_or_below":
+        return ltp <= value
+    return False
+
+
+def _exit_matches_reentry(exit_kind: str, on: str) -> bool:
+    hit = "target" if "target" in exit_kind else "sl" if "sl" in exit_kind else ""
+    return on == "sl_or_target" or on == hit
+
+
+async def _should_reenter(run_id: int, leg_id: int, exit_kind: str) -> bool:
+    state = await state_module.get_run_state(run_id)
+    leg = ((state or {}).get("legs") or {}).get(str(leg_id))
+    if not leg:
+        return False
+    cfg = leg.get("reentry") or {}
+    max_count = int(cfg.get("max_count") or 0)
+    if max_count <= 0:
+        return False
+    if not _exit_matches_reentry(exit_kind, cfg.get("on") or "sl_or_target"):
+        return False
+    if int(leg.get("reentry_count") or 0) >= max_count:
+        return False
+    async with state_module.get_state_lock(run_id):
+        state = await state_module.get_run_state(run_id)
+        if state is None:
+            return False
+        leg = (state.get("legs") or {}).get(str(leg_id))
+        if not leg or leg.get("status") != "closed":
+            return False
+        leg["reentry_count"] = int(leg.get("reentry_count") or 0) + 1
+        if (cfg.get("mode") or "reentry") == "reentry":
+            leg["status"] = "waiting_reentry"
+            should_open_now = False
+        else:
+            leg["status"] = "pending_entry"
+            should_open_now = True
+        await state_module.hydrate_run_state(run_id, state)
+    return should_open_now
+
+
+async def _trigger_entry(run_id: int, leg_id: int) -> None:
+    """Open/re-open a batch leg inside an active run."""
+    from backend.strategy import engine, live_auth
+    from backend.models.strategy_module import SmStrategy, SmStrategyRun
+
+    async with async_session() as db:
+        run = await db.get(SmStrategyRun, run_id)
+        if run is None or run.stopped_at is not None:
+            return
+        strategy = await db.get(SmStrategy, run.strategy_id)
+        if strategy is None:
+            return
+
+        auth_token: Optional[str] = None
+        broker = run.broker
+        config: Optional[dict] = None
+        if run.mode == "live":
+            ctx = await live_auth.resolve_live_auth(
+                db, user_id=strategy.user_id, broker=run.broker,
+            )
+            if ctx is None:
+                logger.warning(
+                    "Auto-entry refused for run %d leg %d: no active broker auth.",
+                    run_id, leg_id,
+                )
+                return
+            auth_token = ctx.auth_token
+            config = ctx.config
+        try:
+            await engine.enter_batch_leg_for_run(
+                db,
+                strategy=strategy,
+                run=run,
+                leg_id=leg_id,
+                mode=run.mode,
+                broker=broker,
+                auth_token=auth_token,
+                config=config,
+            )
+        except Exception:
+            logger.exception("Auto-entry failed for run %d leg %d", run_id, leg_id)
+
+
 async def _trigger_exit(run_id: int, leg_id: int, exit_kind: str) -> None:
     """Engine fires an exit when a leg's rule hits."""
     from backend.strategy import engine, live_auth
@@ -493,6 +666,15 @@ async def _trigger_exit(run_id: int, leg_id: int, exit_kind: str) -> None:
         # and the next /start refuses to fire. Batch-mode only — signal-
         # mode cycling is preserved inside _finalize_run_if_all_flat.
         try:
+            state = await state_module.get_run_state(run_id)
+            leg = ((state or {}).get("legs") or {}).get(str(leg_id))
+            cfg = (leg or {}).get("reentry") or {}
+            if (
+                exit_kind in {"exit_sl", "exit_target", "exit_underlying_sl", "exit_underlying_target"}
+                and int(cfg.get("max_count") or 0) > int((leg or {}).get("reentry_count") or 0)
+                and _exit_matches_reentry(exit_kind, cfg.get("on") or "sl_or_target")
+            ):
+                return
             await engine._finalize_run_if_all_flat(  # noqa: SLF001
                 db, strategy=strategy, run=run,
             )

--- a/backend/test/test_underlying_reentry_config.py
+++ b/backend/test/test_underlying_reentry_config.py
@@ -1,0 +1,61 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas.strategy_module import Leg
+from backend.strategy.tick_processor import _compare_trigger
+
+
+def _base_option_leg(**overrides):
+    data = {
+        "id": 1,
+        "segment": "options",
+        "expiry": "current_month",
+        "lots": 1,
+        "position": "S",
+        "option_type": "CE",
+        "strike_mode": "atm",
+        "atm_offset": "ATM",
+        "target_pts": None,
+        "sl_pts": 10,
+        "trail": {"x": 0, "y": 0},
+    }
+    data.update(overrides)
+    return data
+
+
+def test_leg_accepts_underlying_entry_risk_and_reentry_config():
+    leg = Leg.model_validate(_base_option_leg(
+        underlying_entry={"operator": "is_above", "value": 22600},
+        underlying_risk={"sl_pts": 50, "target_pts": 100},
+        reentry={"mode": "reexecute", "max_count": 2, "on": "sl_or_target"},
+    ))
+
+    assert leg.underlying_entry is not None
+    assert leg.underlying_entry.operator == "is_above"
+    assert leg.underlying_risk is not None
+    assert leg.underlying_risk.target_pts == 100
+    assert leg.reentry is not None
+    assert leg.reentry.mode == "reexecute"
+
+
+def test_leg_rejects_unknown_underlying_operator():
+    with pytest.raises(ValidationError):
+        Leg.model_validate(_base_option_leg(
+            underlying_entry={"operator": "crosses_above", "value": 22600},
+        ))
+
+
+@pytest.mark.parametrize(
+    ("operator", "ltp", "value", "expected"),
+    [
+        ("is_above", 101, 100, True),
+        ("is_above", 100, 100, False),
+        ("is_below", 99, 100, True),
+        ("equal_or_above", 100, 100, True),
+        ("equal_or_below", 100, 100, True),
+        ("equal_to", 100, 100, True),
+        ("equal_to", 101, 100, False),
+    ],
+)
+def test_compare_underlying_trigger(operator, ltp, value, expected):
+    assert _compare_trigger(ltp, operator, value) is expected

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -68,6 +68,14 @@ import {
   type WsStatus,
 } from "@/hooks/useStrategyWebSocket";
 
+const TRIGGER_OPERATOR_LABELS: Record<string, string> = {
+  equal_to: "Equal To",
+  is_above: "Is Above",
+  is_below: "Is Below",
+  equal_or_above: "Equal Or Above",
+  equal_or_below: "Equal Or Below",
+};
+
 function statusBadgeVariant(
   status: StrategyStatus,
 ): "default" | "secondary" | "destructive" | "outline" {
@@ -2261,30 +2269,53 @@ function RiskTab({ strategy }: { strategy: Strategy }) {
                   <th className="px-2 py-1 text-left">Type</th>
                   <th className="px-2 py-1 text-right">SL pts</th>
                   <th className="px-2 py-1 text-right">Target pts</th>
+                  <th className="px-2 py-1 text-left">Underlying entry</th>
+                  <th className="px-2 py-1 text-left">Underlying risk</th>
+                  <th className="px-2 py-1 text-left">Re-entry</th>
                   <th className="px-2 py-1 text-right">Trail X / Y</th>
                 </tr>
               </thead>
               <tbody>
-                {strategy.legs.map((leg) => (
-                  <tr key={leg.id} className="border-t">
-                    <td className="px-2 py-1.5">{leg.id}</td>
-                    <td className="px-2 py-1.5">
-                      <Badge variant="outline" className="text-xs">
-                        {leg.position} · {leg.segment}
-                        {leg.option_type ? ` · ${leg.option_type}` : ""}
-                      </Badge>
-                    </td>
-                    <td className="px-2 py-1.5 text-right font-mono">
-                      {leg.sl_pts ?? "—"}
-                    </td>
-                    <td className="px-2 py-1.5 text-right font-mono">
-                      {leg.target_pts ?? "—"}
-                    </td>
-                    <td className="px-2 py-1.5 text-right font-mono">
-                      {leg.trail.x} / {leg.trail.y}
-                    </td>
-                  </tr>
-                ))}
+                {strategy.legs.map((leg) => {
+                  const underlyingEntry = leg.underlying_entry
+                    ? `${TRIGGER_OPERATOR_LABELS[leg.underlying_entry.operator] ?? leg.underlying_entry.operator} ${leg.underlying_entry.value}`
+                    : "—";
+                  const underlyingRisk = leg.underlying_risk
+                    ? `SL ${leg.underlying_risk.sl_pts ?? "—"} / Tgt ${leg.underlying_risk.target_pts ?? "—"}`
+                    : "—";
+                  const reentry = leg.reentry
+                    ? `${leg.reentry.mode} × ${leg.reentry.max_count} (${leg.reentry.on})`
+                    : "—";
+                  return (
+                    <tr key={leg.id} className="border-t">
+                      <td className="px-2 py-1.5">{leg.id}</td>
+                      <td className="px-2 py-1.5">
+                        <Badge variant="outline" className="text-xs">
+                          {leg.position} · {leg.segment}
+                          {leg.option_type ? ` · ${leg.option_type}` : ""}
+                        </Badge>
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono">
+                        {leg.sl_pts ?? "—"}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono">
+                        {leg.target_pts ?? "—"}
+                      </td>
+                      <td className="px-2 py-1.5 font-mono">
+                        {underlyingEntry}
+                      </td>
+                      <td className="px-2 py-1.5 font-mono">
+                        {underlyingRisk}
+                      </td>
+                      <td className="px-2 py-1.5 font-mono">
+                        {reentry}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono">
+                        {leg.trail.x} / {leg.trail.y}
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -56,6 +56,7 @@ import {
   type StrategyDirection,
   type StrategyKind,
   type StrategyType,
+  type TriggerOperator,
   type StrategyUpdate,
   type UniverseTab,
 } from "@/types/strategy_module";
@@ -67,6 +68,18 @@ const TABS: UniverseTab[] = [
   "stocks_fno",
   "mcx",
 ];
+
+const TRIGGER_OPERATOR_LABELS: Record<TriggerOperator, string> = {
+  equal_to: "Equal To",
+  is_above: "Is Above",
+  is_below: "Is Below",
+  equal_or_above: "Equal Or Above",
+  equal_or_below: "Equal Or Below",
+};
+
+const TRIGGER_OPERATORS = Object.keys(
+  TRIGGER_OPERATOR_LABELS,
+) as TriggerOperator[];
 
 function freshLeg(id: number, tab: UniverseTab): Leg {
   const allowedExpiries = expiriesFor(tab, "options");
@@ -83,6 +96,9 @@ function freshLeg(id: number, tab: UniverseTab): Leg {
     target_pts: null,
     sl_pts: null,
     trail: { x: 0, y: 0 },
+    underlying_entry: null,
+    underlying_risk: null,
+    reentry: null,
     momentum: null,
   };
 }
@@ -433,6 +449,168 @@ function LegCard({
               Leave blank (or 0) for a classic fixed-distance trail driven by X
               alone.
             </p>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Underlying entry</Label>
+            <select
+              value={leg.underlying_entry?.operator ?? ""}
+              onChange={(e) =>
+                update(
+                  "underlying_entry",
+                  e.target.value
+                    ? {
+                        operator: e.target.value as TriggerOperator,
+                        value: leg.underlying_entry?.value ?? 0,
+                      }
+                    : null,
+                )
+              }
+              className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+            >
+              <option value="">Off</option>
+              {TRIGGER_OPERATORS.map((op) => (
+                <option key={op} value={op}>
+                  {TRIGGER_OPERATOR_LABELS[op]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Underlying trigger value</Label>
+            <Input
+              type="number"
+              step={0.01}
+              min={0}
+              disabled={!leg.underlying_entry}
+              value={leg.underlying_entry?.value ?? ""}
+              placeholder="Spot/Future level"
+              onChange={(e) =>
+                update(
+                  "underlying_entry",
+                  leg.underlying_entry
+                    ? {
+                        ...leg.underlying_entry,
+                        value: e.target.value === "" ? 0 : Number(e.target.value),
+                      }
+                    : null,
+                )
+              }
+              className="h-9"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Re-entry mode</Label>
+            <select
+              value={leg.reentry?.mode ?? ""}
+              onChange={(e) =>
+                update(
+                  "reentry",
+                  e.target.value
+                    ? {
+                        mode: e.target.value as "reentry" | "recost" | "reexecute",
+                        max_count: leg.reentry?.max_count ?? 1,
+                        on: leg.reentry?.on ?? "sl_or_target",
+                      }
+                    : null,
+                )
+              }
+              className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+            >
+              <option value="">Off</option>
+              <option value="reentry">Re-entry</option>
+              <option value="recost">Re-cost</option>
+              <option value="reexecute">Re-execute</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-4">
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Underlying SL (pts)</Label>
+            <Input
+              type="number"
+              step={0.01}
+              min={0}
+              value={leg.underlying_risk?.sl_pts ?? ""}
+              placeholder="0 = off"
+              onChange={(e) =>
+                update("underlying_risk", {
+                  ...(leg.underlying_risk ?? {}),
+                  sl_pts: e.target.value === "" ? null : Number(e.target.value),
+                  target_pts: leg.underlying_risk?.target_pts ?? null,
+                })
+              }
+              className="h-9"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Underlying target (pts)</Label>
+            <Input
+              type="number"
+              step={0.01}
+              min={0}
+              value={leg.underlying_risk?.target_pts ?? ""}
+              placeholder="0 = off"
+              onChange={(e) =>
+                update("underlying_risk", {
+                  ...(leg.underlying_risk ?? {}),
+                  sl_pts: leg.underlying_risk?.sl_pts ?? null,
+                  target_pts: e.target.value === "" ? null : Number(e.target.value),
+                })
+              }
+              className="h-9"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Re-entry count</Label>
+            <Input
+              type="number"
+              step={1}
+              min={0}
+              disabled={!leg.reentry}
+              value={leg.reentry?.max_count ?? ""}
+              placeholder="0 = off"
+              onChange={(e) =>
+                update(
+                  "reentry",
+                  leg.reentry
+                    ? {
+                        ...leg.reentry,
+                        max_count: e.target.value === "" ? 0 : Number(e.target.value),
+                      }
+                    : null,
+                )
+              }
+              className="h-9"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs uppercase">Re-entry on</Label>
+            <select
+              disabled={!leg.reentry}
+              value={leg.reentry?.on ?? "sl_or_target"}
+              onChange={(e) =>
+                update(
+                  "reentry",
+                  leg.reentry
+                    ? {
+                        ...leg.reentry,
+                        on: e.target.value as "sl" | "target" | "sl_or_target",
+                      }
+                    : null,
+                )
+              }
+              className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm disabled:opacity-50"
+            >
+              <option value="sl_or_target">SL or Target</option>
+              <option value="sl">SL only</option>
+              <option value="target">Target only</option>
+            </select>
           </div>
         </div>
       </CardContent>
@@ -1070,6 +1248,18 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
         }
         if (!leg.qty || leg.qty < 1) {
           toast.error(`Leg ${leg.id}: quantity must be at least 1`);
+          return;
+        }
+      }
+    }
+    if (!isSignal) {
+      for (const leg of legs) {
+        if (leg.underlying_entry && leg.underlying_entry.value <= 0) {
+          toast.error(`Leg ${leg.id}: underlying trigger value must be above 0`);
+          return;
+        }
+        if (leg.reentry && leg.reentry.max_count <= 0) {
+          toast.error(`Leg ${leg.id}: re-entry count must be above 0`);
           return;
         }
       }

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -80,6 +80,29 @@ export interface TrailConfig {
   y: number;
 }
 
+export type TriggerOperator =
+  | "equal_to"
+  | "is_above"
+  | "is_below"
+  | "equal_or_above"
+  | "equal_or_below";
+
+export interface UnderlyingTriggerConfig {
+  operator: TriggerOperator;
+  value: number;
+}
+
+export interface UnderlyingRiskConfig {
+  sl_pts?: number | null;
+  target_pts?: number | null;
+}
+
+export interface ReEntryConfig {
+  mode: "reentry" | "recost" | "reexecute";
+  max_count: number;
+  on: "sl" | "target" | "sl_or_target";
+}
+
 export interface Leg {
   id: number;
   segment: Segment;
@@ -109,6 +132,9 @@ export interface Leg {
   target_pts?: number | null;
   sl_pts?: number | null;
   trail: TrailConfig;
+  underlying_entry?: UnderlyingTriggerConfig | null;
+  underlying_risk?: UnderlyingRiskConfig | null;
+  reentry?: ReEntryConfig | null;
   momentum?: Record<string, unknown> | null;
 }
 


### PR DESCRIPTION
## Summary
- Add backend config support for underlying-based entry triggers, underlying-based SL/target, and re-entry modes.
- Let batch runs keep underlying-triggered legs configured until the underlying condition fires.
- Subscribe active runs to underlying ticks when needed, evaluate underlying exits, and reopen legs for recost/reexecute immediately or reentry when price returns to the prior entry.
- Preserve underlying/re-entry state during Redis init, fills, and recovery.

## Scope
- Includes underlying-based entries/exits and re-entry/recost/reexecute runtime support.
- Does not include adjustment-builder changes.
- Does not modify the earlier entry strike-mode PR.

## Validation
- `.venv/bin/python -m py_compile backend/schemas/strategy_module.py backend/strategy/engine.py backend/strategy/tick_processor.py backend/strategy/state.py backend/strategy/recovery.py backend/test/test_underlying_reentry_config.py`
- lightweight schema/helper validation script
- `git diff --check`

## Notes
- `pytest` is not installed in the local venv, so the focused pytest file could not be executed here with `python -m pytest`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds underlying-based entries and exits with auto re-entry for batch runs. Adds per-leg configs, tick-driven placement, and state/recovery updates, plus UI to configure and view them.

- **New Features**
  - Per-leg underlying-based entry: legs start as "configured", subscribe to the underlying, flip to "pending_entry" when the trigger hits, then place inside the active run via a new enter-within-run path.
  - Underlying-based risk: per-leg `underlying_risk.sl_pts`/`target_pts` compare the underlying’s move from `entry_underlying_ltp`; exits emit `exit_underlying_sl`/`exit_underlying_target`.
  - Re-entry: per-leg `reentry` with `mode` (`reentry` waits for return-to-entry; `recost`/`reexecute` place immediately), `max_count`, and `on` (`sl`, `target`, `sl_or_target`); tracks `reentry_count` and avoids restarting runs.
  - State/recovery: track `underlying_ltp`, `entry_underlying_ltp`, `entry_count`, `reentry_count`, `last_exit_kind`, `last_exit_price`; new statuses `pending_entry` and `waiting_reentry`; auto-subscribe to the underlying on start/recovery when any leg uses underlying entry/risk.
  - Schema/types/UI: backend `Leg` adds optional `underlying_entry`, `underlying_risk`, `reentry`; frontend Wizard adds editors with basic validation; Detail shows new columns; types updated; tests cover schema validation and trigger comparisons.

<sup>Written for commit 5a53a091fb7250ab7b5925593607b529075262cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openbull/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

